### PR TITLE
Add "All" button to bill splitter item assignment

### DIFF
--- a/src/pages/tools/bill.astro
+++ b/src/pages/tools/bill.astro
@@ -152,6 +152,18 @@ Here's an example of the expected format with sample data:
     setPersonShares(newShares);
   };
 
+  const toggleAllPeople = (itemUniqueId) => {
+    const newAssignments = { ...itemAssignments };
+    const currentAssignees = newAssignments[itemUniqueId] || [];
+    if (currentAssignees.length === people.length) {
+      delete newAssignments[itemUniqueId];
+    } else {
+      newAssignments[itemUniqueId] = [...people];
+    }
+    setItemAssignments(newAssignments);
+    updateSharesFromAssignments(newAssignments);
+  };
+
   const togglePersonAssignment = (itemUniqueId, person) => {
     const newAssignments = { ...itemAssignments };
     const currentAssignees = newAssignments[itemUniqueId] || [];
@@ -319,7 +331,7 @@ Here's an example of the expected format with sample data:
                       {isFirst ? <input type="number" min="0" step="0.01" value={orig.price} onChange={(e) => updateItemPrice(orig.id, e.target.value)} className="w-20 border dark:border-gray-500 p-1 rounded text-right dark:bg-gray-600" /> : <span className="text-right block">{item.price.toFixed(2)}</span>}
                     </td>
                     <td className="border dark:border-gray-600 p-1 sm:p-2">
-                      <div className="flex flex-wrap gap-1">{people.map(p => <button key={p} onClick={() => togglePersonAssignment(item.uniqueId, p)} className={`px-1 sm:px-2 py-1 text-xs rounded-full ${assignees.includes(p) ? 'bg-blue-500 text-white' : 'bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300'}`}>{p}</button>)}</div>
+                      <div className="flex flex-wrap gap-1"><button onClick={() => toggleAllPeople(item.uniqueId)} className={`px-1 sm:px-2 py-1 text-xs rounded-full font-semibold ${assignees.length === people.length ? 'bg-blue-500 text-white' : 'bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300'}`}>All</button>{people.map(p => <button key={p} onClick={() => togglePersonAssignment(item.uniqueId, p)} className={`px-1 sm:px-2 py-1 text-xs rounded-full ${assignees.includes(p) ? 'bg-blue-500 text-white' : 'bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300'}`}>{p}</button>)}</div>
                     </td>
                     <td className="border dark:border-gray-600 p-1 sm:p-2 text-center">
                       <button onClick={() => toggleExpandedRow(item.uniqueId)} disabled={!canItemBeSplit(item.uniqueId)} className={`px-2 py-1 rounded text-xs ${canItemBeSplit(item.uniqueId) ? 'bg-blue-500 hover:bg-blue-600 text-white' : 'bg-gray-300 dark:bg-gray-700 text-gray-500 cursor-not-allowed'} ${expandedRows[item.uniqueId] ? 'bg-blue-700' : ''}`}>{expandedRows[item.uniqueId] ? 'Hide' : 'Split'}</button>


### PR DESCRIPTION
Adds a toggle button that selects/deselects all people for an item,
making it faster to assign shared items like tips or service charges.

https://claude.ai/code/session_01MMgCXEjwEQLe17HhEm1NXV