### PR TITLE
Add line item translation support to bill splitter

### DIFF
--- a/src/pages/tools/bill.astro
+++ b/src/pages/tools/bill.astro
@@ -48,12 +48,12 @@ const Component = () => {
   };
 
   const defaultItems = [
-    { name: 'Caesar Salad', price: 12.00, quantity: 1 },
-    { name: 'Coffee', price: 5.00, quantity: 2 },
-    { name: 'Burger', price: 16.00, quantity: 1 },
-    { name: 'Pasta', price: 14.00, quantity: 1 },
-    { name: 'Sparkling Water', price: 4.00, quantity: 1 },
-    { name: 'Garlic Bread', price: 8.00, quantity: 1 },
+    { name: 'Salade César', price: 12.00, quantity: 1, translation: 'Caesar Salad' },
+    { name: 'Café', price: 5.00, quantity: 2, translation: 'Coffee' },
+    { name: 'Hamburger', price: 16.00, quantity: 1, translation: 'Hamburger' },
+    { name: 'Pâtes', price: 14.00, quantity: 1, translation: 'Pasta' },
+    { name: 'Eau Pétillante', price: 4.00, quantity: 1, translation: 'Sparkling Water' },
+    { name: 'Pain à l\'Ail', price: 8.00, quantity: 1, translation: 'Garlic Bread' },
   ].map((item, index) => ({ ...item, id: index + 1 }));
 
   const defaultPeople = ['Alice', 'Bob', 'Charlie'];
@@ -91,10 +91,10 @@ const Component = () => {
   const [showCurrencySettings, setShowCurrencySettings] = useState(loadFromLocalStorage('showCurrencySettings', false));
   const [showPeopleSettings, setShowPeopleSettings] = useState(loadFromLocalStorage('showPeopleSettings', false));
 
-  const claudePromptText = `This is an image of a receipt. Extract all the items with their name, price, and quantity. Also identify the currency used in the receipt (£, $, €, etc.).
+  const claudePromptText = `This is an image of a receipt. Extract all the items with their name, price, quantity, and an English translation of the item name. Also identify the currency used in the receipt (£, $, €, etc.).
 
 Format the output as a JSON object with two fields:
-1. "items": An array of items, each with name, price (as a number), and quantity (as a number)
+1. "items": An array of items, each with name (as it appears on the receipt), price (as a number), quantity (as a number), and translation (English translation of the item name)
 2. "currency": The currency symbol used in the receipt (£, $, €, etc.)
 
 If this is not a receipt, simply respond with: "Not a receipt"
@@ -102,7 +102,7 @@ If this is not a receipt, simply respond with: "Not a receipt"
 Here's an example of the expected format with sample data:
 {
   "items": ${JSON.stringify(defaultItems.map(({id, ...item}) => item))},
-  "currency": "$"
+  "currency": "€"
 }`;
 
   useEffect(() => { localStorage.setItem('billSplitter_people', JSON.stringify(people)); }, [people]);
@@ -274,7 +274,7 @@ Here's an example of the expected format with sample data:
             try {
               const data = JSON.parse(e.target.value.trim());
               if (data.items && Array.isArray(data.items)) {
-                setItems(data.items.map((item, i) => ({ id: i + 1, name: item.name || 'Unnamed', price: parseFloat(item.price) || 0, quantity: parseInt(item.quantity) || 1 })));
+                setItems(data.items.map((item, i) => ({ id: i + 1, name: item.name || 'Unnamed', price: parseFloat(item.price) || 0, quantity: parseInt(item.quantity) || 1, translation: item.translation || '' })));
                 if (data.currency) setCurrency(data.currency);
                 setPersonShares({}); setItemAssignments({}); setExpandedRows({}); setProcessingError(null);
               } else setProcessingError('Invalid format');
@@ -324,8 +324,13 @@ Here's an example of the expected format with sample data:
                 <React.Fragment key={item.uniqueId}>
                   <tr className={`${isComplete ? 'bg-green-50 dark:bg-green-900/20' : ''} ${isOver ? 'bg-red-50 dark:bg-red-900/20' : ''} hover:bg-gray-50 dark:hover:bg-gray-700`}>
                     <td className="border dark:border-gray-600 p-1 sm:p-2">
-                      {isFirst ? <input type="text" value={orig.name} onChange={(e) => updateItemName(orig.id, e.target.value)} className="w-full border dark:border-gray-500 p-1 rounded dark:bg-gray-600" /> : <span>{item.name}</span>}
-                      {item.originalQuantity > 1 && ` (${parseInt(item.uniqueId.split('-')[1]) + 1}/${item.originalQuantity})`}
+                      <div>
+                        <div className="flex items-center">
+                          {isFirst ? <input type="text" value={orig.name} onChange={(e) => updateItemName(orig.id, e.target.value)} className="w-full border dark:border-gray-500 p-1 rounded dark:bg-gray-600" /> : <span>{item.name}</span>}
+                          {item.originalQuantity > 1 && <span className="ml-1 whitespace-nowrap">({parseInt(item.uniqueId.split('-')[1]) + 1}/{item.originalQuantity})</span>}
+                        </div>
+                        {item.translation && <div className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">{item.translation}</div>}
+                      </div>
                     </td>
                     <td className="border dark:border-gray-600 p-1 sm:p-2">
                       {isFirst ? <input type="number" min="0" step="0.01" value={orig.price} onChange={(e) => updateItemPrice(orig.id, e.target.value)} className="w-20 border dark:border-gray-500 p-1 rounded text-right dark:bg-gray-600" /> : <span className="text-right block">{item.price.toFixed(2)}</span>}


### PR DESCRIPTION
Update the Claude prompt to request English translations of each item
name on foreign receipts. Translations display below item names in
a lighter grey text. Example data now uses French item names.

https://claude.ai/code/session_01QWyFQbEz8RUFsTLLN95UAs