### PR TITLE
Clarify that price in Claude prompt means unit price, not line total

### DIFF
--- a/src/pages/tools/bill.astro
+++ b/src/pages/tools/bill.astro
@@ -91,7 +91,7 @@ const Component = () => {
   const [showCurrencySettings, setShowCurrencySettings] = useState(loadFromLocalStorage('showCurrencySettings', false));
   const [showPeopleSettings, setShowPeopleSettings] = useState(loadFromLocalStorage('showPeopleSettings', false));
 
-  const claudePromptText = `This is an image of a receipt. Extract all the items with their name, price, quantity, and an English translation of the item name. Also identify the currency used in the receipt (£, $, €, etc.).
+  const claudePromptText = `This is an image of a receipt. Extract all the items with their name, price (as a unit price, not the line total — e.g. if the receipt shows 2 x 2.80€, the price is 2.80, not 5.60), quantity, and an English translation of the item name. Also identify the currency used in the receipt (£, $, €, etc.).
 
 Format the output as a JSON object with two fields:
 1. "items": An array of items, each with name (as it appears on the receipt), price (as a number), quantity (as a number), and translation (English translation of the item name)

--- a/src/pages/tools/bill.astro
+++ b/src/pages/tools/bill.astro
@@ -91,10 +91,10 @@ const Component = () => {
   const [showCurrencySettings, setShowCurrencySettings] = useState(loadFromLocalStorage('showCurrencySettings', false));
   const [showPeopleSettings, setShowPeopleSettings] = useState(loadFromLocalStorage('showPeopleSettings', false));
 
-  const claudePromptText = `This is an image of a receipt. Extract all the items with their name, price (as a unit price, not the line total — e.g. if the receipt shows 2 x 2.80€, the price is 2.80, not 5.60), quantity, and an English translation of the item name. Also identify the currency used in the receipt (£, $, €, etc.).
+  const claudePromptText = `This is an image of a receipt. Extract all the items with their name, price, quantity, and an English translation of the item name. Also identify the currency used in the receipt (£, $, €, etc.).
 
 Format the output as a JSON object with two fields:
-1. "items": An array of items, each with name (as it appears on the receipt), price (as a number), quantity (as a number), and translation (English translation of the item name)
+1. "items": An array of items, each with name (as it appears on the receipt), price (as a unit price, not the line total — e.g. if the receipt shows 2 x 2.80€, the price is 2.80, not 5.60), quantity (as a number), and translation (English translation of the item name)
 2. "currency": The currency symbol used in the receipt (£, $, €, etc.)
 
 If this is not a receipt, simply respond with: "Not a receipt"


### PR DESCRIPTION
Add parenthetical example to the receipt-scanning prompt so Claude
extracts the per-unit price (e.g. 2.80) rather than the line total
(e.g. 5.60 for 2 x 2.80€).

https://claude.ai/code/session_01PRsCT32BV8r9uN3mHFKgWg