### PR TITLE
Improve bill splitter UI: collapsible tax section and better arrows

### DIFF
--- a/src/pages/tools/bill.astro
+++ b/src/pages/tools/bill.astro
@@ -94,7 +94,7 @@ const Component = () => {
   const [serviceCharge, setServiceCharge] = useState(loadFromLocalStorage('serviceCharge', 0));
   const [serviceChargeMode, setServiceChargeMode] = useState(loadFromLocalStorage('serviceChargeMode', '%'));
   const [expandedSummary, setExpandedSummary] = useState({});
-  const [showTaxSettings, setShowTaxSettings] = useState(loadFromLocalStorage('showTaxSettings', true));
+  const [showTaxSettings, setShowTaxSettings] = useState(true);
 
   const claudePromptText = `This is an image of a receipt. Extract all the items with their name, price, quantity, and an English translation of the item name. Also identify the currency used in the receipt (£, $, €, etc.). If the receipt shows a tax/VAT amount or a service charge, extract those too.
 
@@ -137,7 +137,7 @@ Here's an example of the expected format with sample data:
   useEffect(() => { localStorage.setItem('billSplitter_tax', JSON.stringify(tax)); }, [tax]);
   useEffect(() => { localStorage.setItem('billSplitter_serviceCharge', JSON.stringify(serviceCharge)); }, [serviceCharge]);
   useEffect(() => { localStorage.setItem('billSplitter_serviceChargeMode', JSON.stringify(serviceChargeMode)); }, [serviceChargeMode]);
-  useEffect(() => { localStorage.setItem('billSplitter_showTaxSettings', JSON.stringify(showTaxSettings)); }, [showTaxSettings]);
+
 
   const expandedItems = items.flatMap(item =>
     Array(item.quantity).fill().map((_, i) => ({
@@ -253,12 +253,12 @@ Here's an example of the expected format with sample data:
   };
 
   const resetData = () => {
-    ['people','personShares','itemAssignments','items','expandedRows','currency','homeCurrency','exchangeRate','showCurrencySettings','showPeopleSettings','tax','serviceCharge','serviceChargeMode','showTaxSettings']
+    ['people','personShares','itemAssignments','items','expandedRows','currency','homeCurrency','exchangeRate','showCurrencySettings','showPeopleSettings','tax','serviceCharge','serviceChargeMode']
       .forEach(k => localStorage.removeItem(`billSplitter_${k}`));
     setPeople(defaultPeople); setPersonShares(defaultShares); setItemAssignments(defaultAssignments); setItems(defaultItems);
     setExpandedRows({}); setProcessingError(null); setCurrency('$'); setHomeCurrency('$');
     setExchangeRate(1); setShowCurrencySettings(false); setShowPeopleSettings(false);
-    setTax(0); setServiceCharge(0); setServiceChargeMode('%'); setShowTaxSettings(true); setExpandedSummary({});
+    setTax(0); setServiceCharge(0); setServiceChargeMode('%'); setExpandedSummary({});
   };
 
   return (

--- a/src/pages/tools/bill.astro
+++ b/src/pages/tools/bill.astro
@@ -94,7 +94,7 @@ const Component = () => {
   const [serviceCharge, setServiceCharge] = useState(loadFromLocalStorage('serviceCharge', 0));
   const [serviceChargeMode, setServiceChargeMode] = useState(loadFromLocalStorage('serviceChargeMode', '%'));
   const [expandedSummary, setExpandedSummary] = useState({});
-  const [showTaxSettings, setShowTaxSettings] = useState(true);
+  const [showTaxSettings, setShowTaxSettings] = useState(false);
 
   const claudePromptText = `This is an image of a receipt. Extract all the items with their name, price, quantity, and an English translation of the item name. Also identify the currency used in the receipt (£, $, €, etc.). If the receipt shows a tax/VAT amount or a service charge, extract those too.
 

--- a/src/pages/tools/bill.astro
+++ b/src/pages/tools/bill.astro
@@ -94,6 +94,7 @@ const Component = () => {
   const [serviceCharge, setServiceCharge] = useState(loadFromLocalStorage('serviceCharge', 0));
   const [serviceChargeMode, setServiceChargeMode] = useState(loadFromLocalStorage('serviceChargeMode', '%'));
   const [expandedSummary, setExpandedSummary] = useState({});
+  const [showTaxSettings, setShowTaxSettings] = useState(loadFromLocalStorage('showTaxSettings', true));
 
   const claudePromptText = `This is an image of a receipt. Extract all the items with their name, price, quantity, and an English translation of the item name. Also identify the currency used in the receipt (£, $, €, etc.). If the receipt shows a tax/VAT amount or a service charge, extract those too.
 
@@ -136,6 +137,7 @@ Here's an example of the expected format with sample data:
   useEffect(() => { localStorage.setItem('billSplitter_tax', JSON.stringify(tax)); }, [tax]);
   useEffect(() => { localStorage.setItem('billSplitter_serviceCharge', JSON.stringify(serviceCharge)); }, [serviceCharge]);
   useEffect(() => { localStorage.setItem('billSplitter_serviceChargeMode', JSON.stringify(serviceChargeMode)); }, [serviceChargeMode]);
+  useEffect(() => { localStorage.setItem('billSplitter_showTaxSettings', JSON.stringify(showTaxSettings)); }, [showTaxSettings]);
 
   const expandedItems = items.flatMap(item =>
     Array(item.quantity).fill().map((_, i) => ({
@@ -251,12 +253,12 @@ Here's an example of the expected format with sample data:
   };
 
   const resetData = () => {
-    ['people','personShares','itemAssignments','items','expandedRows','currency','homeCurrency','exchangeRate','showCurrencySettings','showPeopleSettings','tax','serviceCharge','serviceChargeMode']
+    ['people','personShares','itemAssignments','items','expandedRows','currency','homeCurrency','exchangeRate','showCurrencySettings','showPeopleSettings','tax','serviceCharge','serviceChargeMode','showTaxSettings']
       .forEach(k => localStorage.removeItem(`billSplitter_${k}`));
     setPeople(defaultPeople); setPersonShares(defaultShares); setItemAssignments(defaultAssignments); setItems(defaultItems);
     setExpandedRows({}); setProcessingError(null); setCurrency('$'); setHomeCurrency('$');
     setExchangeRate(1); setShowCurrencySettings(false); setShowPeopleSettings(false);
-    setTax(0); setServiceCharge(0); setServiceChargeMode('%'); setExpandedSummary({});
+    setTax(0); setServiceCharge(0); setServiceChargeMode('%'); setShowTaxSettings(true); setExpandedSummary({});
   };
 
   return (
@@ -395,24 +397,30 @@ Here's an example of the expected format with sample data:
       </div>
 
       <div className="mb-6">
-        <h2 className="text-lg font-semibold mb-2">Tax & Service Charge</h2>
-        <div className="bg-gray-100 dark:bg-gray-700 p-3 rounded grid grid-cols-1 md:grid-cols-2 gap-3">
-          <div>
-            <label className="block text-sm font-medium mb-1">Tax ({currency})</label>
-            <input type="number" min="0" step="0.01" value={tax} onChange={(e) => setTax(parseFloat(e.target.value) || 0)} className="w-32 p-2 border dark:border-gray-600 rounded dark:bg-gray-700" />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Service Charge</label>
-            <div className="flex items-center gap-2">
-              <input type="number" min="0" step="0.01" value={serviceCharge} onChange={(e) => setServiceCharge(parseFloat(e.target.value) || 0)} className="w-32 p-2 border dark:border-gray-600 rounded dark:bg-gray-700" />
-              <select value={serviceChargeMode} onChange={(e) => setServiceChargeMode(e.target.value)} className="p-2 border dark:border-gray-600 rounded dark:bg-gray-700">
-                <option value="%">%</option>
-                <option value="fixed">{currency}</option>
-              </select>
-            </div>
-            {serviceChargeMode === '%' && serviceCharge > 0 && <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">= {currency}{serviceChargeAmount.toFixed(2)}</p>}
-          </div>
+        <div className="flex justify-between items-center mb-2">
+          <h2 className="text-lg font-semibold">Tax & Service Charge</h2>
+          <button onClick={() => setShowTaxSettings(!showTaxSettings)} className="text-blue-500 hover:text-blue-700 text-sm">{showTaxSettings ? 'Hide ▲' : 'Show ▼'}</button>
         </div>
+        {!showTaxSettings && <div className="bg-gray-100 dark:bg-gray-700 p-3 rounded text-sm"><span className="font-medium">Tax: {currency}{tax.toFixed(2)}</span><span className="ml-3">Service: {serviceChargeMode === '%' ? `${serviceCharge}%` : `${currency}${serviceCharge.toFixed(2)}`}{serviceChargeMode === '%' && serviceCharge > 0 ? ` (${currency}${serviceChargeAmount.toFixed(2)})` : ''}</span></div>}
+        {showTaxSettings && (
+          <div className="bg-gray-100 dark:bg-gray-700 p-3 rounded grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-medium mb-1">Tax ({currency})</label>
+              <input type="number" min="0" step="0.01" value={tax} onChange={(e) => setTax(parseFloat(e.target.value) || 0)} className="w-32 p-2 border dark:border-gray-600 rounded dark:bg-gray-700" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Service Charge</label>
+              <div className="flex items-center gap-2">
+                <input type="number" min="0" step="0.01" value={serviceCharge} onChange={(e) => setServiceCharge(parseFloat(e.target.value) || 0)} className="w-32 p-2 border dark:border-gray-600 rounded dark:bg-gray-700" />
+                <select value={serviceChargeMode} onChange={(e) => setServiceChargeMode(e.target.value)} className="p-2 border dark:border-gray-600 rounded dark:bg-gray-700">
+                  <option value="%">%</option>
+                  <option value="fixed">{currency}</option>
+                </select>
+              </div>
+              {serviceChargeMode === '%' && serviceCharge > 0 && <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">= {currency}{serviceChargeAmount.toFixed(2)}</p>}
+            </div>
+          </div>
+        )}
       </div>
 
       <div className="mb-6">
@@ -445,7 +453,7 @@ Here's an example of the expected format with sample data:
               const showHome = currency !== homeCurrency && exchangeRate !== 1;
               return <div key={i}>
                 <div className={`flex justify-between py-1 border-b dark:border-gray-700 ${hasExtras ? 'cursor-pointer' : ''}`} onClick={() => hasExtras && setExpandedSummary(prev => ({ ...prev, [p]: !prev[p] }))}>
-                  <span>{p}: {hasExtras && <span className="text-xs text-gray-400">{isExpanded ? '▾' : '▸'}</span>}</span>
+                  <span className="flex items-center gap-1">{hasExtras && <span className="text-base text-gray-400">{isExpanded ? '▾' : '▸'}</span>}{p}:</span>
                   <span className="font-semibold">{currency}{totalStr}{showHome && <span className="text-gray-500 ml-1 text-sm">({homeCurrency}{homeTotal})</span>}</span>
                 </div>
                 {isExpanded && <div className="pl-4 py-1 text-xs text-gray-500 dark:text-gray-400 space-y-0.5">


### PR DESCRIPTION
- Make Tax & Service Charge section collapsible with show/hide toggle,
  displaying a compact summary when collapsed
- Move expand/collapse arrows to the left of person names in the
  summary section and increase their size for better visibility

https://claude.ai/code/session_01YFkVWLDkLuTMKsC3D74HCo