### PR TITLE
Fix stale closure bug in bill splitter username button selection

### DIFF
--- a/src/pages/tools/bill.astro
+++ b/src/pages/tools/bill.astro
@@ -166,28 +166,32 @@ Here's an example of the expected format with sample data:
   };
 
   const toggleAllPeople = (itemUniqueId) => {
-    const newAssignments = { ...itemAssignments };
-    const currentAssignees = newAssignments[itemUniqueId] || [];
-    if (currentAssignees.length === people.length) {
-      delete newAssignments[itemUniqueId];
-    } else {
-      newAssignments[itemUniqueId] = [...people];
-    }
-    setItemAssignments(newAssignments);
-    updateSharesFromAssignments(newAssignments);
+    setItemAssignments(prev => {
+      const newAssignments = { ...prev };
+      const currentAssignees = newAssignments[itemUniqueId] || [];
+      if (currentAssignees.length === people.length) {
+        delete newAssignments[itemUniqueId];
+      } else {
+        newAssignments[itemUniqueId] = [...people];
+      }
+      updateSharesFromAssignments(newAssignments);
+      return newAssignments;
+    });
   };
 
   const togglePersonAssignment = (itemUniqueId, person) => {
-    const newAssignments = { ...itemAssignments };
-    const currentAssignees = newAssignments[itemUniqueId] || [];
-    if (currentAssignees.includes(person)) {
-      newAssignments[itemUniqueId] = currentAssignees.filter(p => p !== person);
-      if (newAssignments[itemUniqueId].length === 0) delete newAssignments[itemUniqueId];
-    } else {
-      newAssignments[itemUniqueId] = [...currentAssignees, person];
-    }
-    setItemAssignments(newAssignments);
-    updateSharesFromAssignments(newAssignments);
+    setItemAssignments(prev => {
+      const newAssignments = { ...prev };
+      const currentAssignees = newAssignments[itemUniqueId] || [];
+      if (currentAssignees.includes(person)) {
+        newAssignments[itemUniqueId] = currentAssignees.filter(p => p !== person);
+        if (newAssignments[itemUniqueId].length === 0) delete newAssignments[itemUniqueId];
+      } else {
+        newAssignments[itemUniqueId] = [...currentAssignees, person];
+      }
+      updateSharesFromAssignments(newAssignments);
+      return newAssignments;
+    });
   };
 
   const handleShareChange = (itemUniqueId, person, share) => {


### PR DESCRIPTION
Use functional updater form of setItemAssignments so rapid clicks
read the latest state instead of a stale closure value.

https://claude.ai/code/session_01RsiAKoWeRoD31aZZDBZ6je