### PR TITLE
Fix build/deploy workflow to support manual workflow_dispatch trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,7 +85,7 @@ jobs:
           cp -r target/public/* ../../public/tools/ynab-reimbursement/
 
       - name: Build Astro
-        if: github.event.action != 'closed' && github.event_name == 'push'
+        if: github.event.action != 'closed' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: npm run build
 
       - name: Build Astro (PR preview)
@@ -94,7 +94,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist


### PR DESCRIPTION
The Astro build step only checked for event_name == 'push', skipping the
build entirely on manual triggers. Added workflow_dispatch to the build
condition and made the deploy condition more explicit.

https://claude.ai/code/session_01NVn76dgQoGo2xdTs4CrW8Q