### PR TITLE
feat: add Password Migration Helper tool

### DIFF
--- a/docs/plans/2026-03-07-password-migration.md
+++ b/docs/plans/2026-03-07-password-migration.md
@@ -1,0 +1,1424 @@
+# Password Migration Helper Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a client-side tool to audit and track migration of a Bitwarden vault to Apple Passwords, Uplock, and Apple Wallet.
+
+**Architecture:** React SPA rendered into an Astro page shell. All state in localStorage via a `useLocalStorage` hook. Bitwarden `.zip` parsed client-side with JSZip. No server, no network requests with vault data. Component-per-view pattern matching the YNAB tool.
+
+**Tech Stack:** React 19, Tailwind CSS 4, JSZip, Vitest + Testing Library
+
+**Spec:** `src/pages/tools/password-migration/spec.allium`
+
+**Bitwarden JSON types:** 1=Login, 2=SecureNote, 3=Card, 4=Identity. Custom field types: 0=text, 1=hidden, 2=boolean.
+
+---
+
+### Task 1: Install JSZip and set up parser module
+
+**Files:**
+- Modify: `package.json` (add jszip dependency)
+- Create: `src/pages/tools/password-migration/_app/parser.js`
+- Test: `src/pages/tools/password-migration/_app/parser.test.js`
+
+**Step 1: Install JSZip**
+
+Run: `npm install jszip`
+
+**Step 2: Write failing tests for the parser**
+
+```js
+// parser.test.js
+import { describe, it, expect } from 'vitest';
+import { parseBitwardenItem, mapFolders } from './parser.js';
+
+describe('mapFolders', () => {
+  it('maps folder IDs to names', () => {
+    const folders = [
+      { id: 'f1', name: 'Social' },
+      { id: 'f2', name: 'Work' },
+    ];
+    expect(mapFolders(folders)).toEqual({ f1: 'Social', f2: 'Work' });
+  });
+
+  it('returns empty map for empty array', () => {
+    expect(mapFolders([])).toEqual({});
+  });
+});
+
+describe('parseBitwardenItem', () => {
+  const folderMap = { 'folder-1': 'Social Media' };
+
+  it('parses a login item', () => {
+    const item = {
+      id: 'abc-123',
+      type: 1,
+      name: 'GitHub',
+      notes: 'my notes',
+      favorite: true,
+      folderId: 'folder-1',
+      login: {
+        uris: [{ uri: 'https://github.com', match: null }],
+        username: 'user@example.com',
+        password: 'secret123',
+        totp: 'otpauth://totp/GitHub?secret=ABC',
+      },
+      fields: [
+        { name: 'API Key', value: 'key-123', type: 1 },
+        { name: 'Recovery', value: 'code1 code2', type: 0 },
+      ],
+    };
+
+    const result = parseBitwardenItem(item, folderMap);
+
+    expect(result.bitwarden_id).toBe('abc-123');
+    expect(result.name).toBe('GitHub');
+    expect(result.type).toBe('login');
+    expect(result.folder_name).toBe('Social Media');
+    expect(result.notes).toBe('my notes');
+    expect(result.is_favorite).toBe(true);
+    expect(result.uris).toEqual([{ uri: 'https://github.com' }]);
+    expect(result.username).toBe('user@example.com');
+    expect(result.password).toBe('secret123');
+    expect(result.totp).toBe('otpauth://totp/GitHub?secret=ABC');
+    expect(result.custom_fields).toEqual([
+      { name: 'API Key', value: 'key-123', is_hidden: true },
+      { name: 'Recovery', value: 'code1 code2', is_hidden: false },
+    ]);
+  });
+
+  it('parses a secure note', () => {
+    const item = {
+      id: 'note-1',
+      type: 2,
+      name: 'Server Info',
+      notes: 'SSH details here',
+      favorite: false,
+      folderId: null,
+      secureNote: {},
+      fields: null,
+    };
+
+    const result = parseBitwardenItem(item, folderMap);
+
+    expect(result.type).toBe('secure_note');
+    expect(result.folder_name).toBeNull();
+    expect(result.custom_fields).toEqual([]);
+  });
+
+  it('parses a card item', () => {
+    const item = {
+      id: 'card-1',
+      type: 3,
+      name: 'Visa',
+      notes: null,
+      favorite: false,
+      folderId: null,
+      card: {
+        cardholderName: 'Oliver',
+        brand: 'Visa',
+        number: '4111111111111111',
+        expMonth: '12',
+        expYear: '2028',
+        code: '123',
+      },
+      fields: null,
+    };
+
+    const result = parseBitwardenItem(item, folderMap);
+
+    expect(result.type).toBe('card');
+    expect(result.card_number).toBe('4111111111111111');
+    expect(result.card_brand).toBe('Visa');
+    expect(result.card_exp_month).toBe('12');
+    expect(result.card_code).toBe('123');
+  });
+
+  it('parses an identity item', () => {
+    const item = {
+      id: 'id-1',
+      type: 4,
+      name: 'Personal',
+      notes: null,
+      favorite: false,
+      folderId: null,
+      identity: {
+        title: 'Mr',
+        firstName: 'Oliver',
+        middleName: null,
+        lastName: 'Smith',
+        email: 'oliver@example.com',
+        phone: '+441234567890',
+        address1: '123 Main St',
+        address2: null,
+        address3: null,
+        city: 'London',
+        state: null,
+        postalCode: 'SW1A 1AA',
+        country: 'GB',
+        username: null,
+      },
+      fields: null,
+    };
+
+    const result = parseBitwardenItem(item, folderMap);
+
+    expect(result.type).toBe('identity');
+    expect(result.identity_first_name).toBe('Oliver');
+    expect(result.identity_email).toBe('oliver@example.com');
+    expect(result.identity_phone).toBe('+441234567890');
+    expect(result.identity_address).toBe('123 Main St, London, SW1A 1AA, GB');
+  });
+});
+```
+
+**Step 3: Run tests to verify they fail**
+
+Run: `npm test -- src/pages/tools/password-migration/_app/parser.test.js`
+Expected: FAIL (module not found)
+
+**Step 4: Implement the parser**
+
+```js
+// parser.js
+
+const TYPE_MAP = { 1: 'login', 2: 'secure_note', 3: 'card', 4: 'identity' };
+const FIELD_TYPE_HIDDEN = 1;
+
+export function mapFolders(folders) {
+  const map = {};
+  for (const f of folders) {
+    map[f.id] = f.name;
+  }
+  return map;
+}
+
+export function parseBitwardenItem(item, folderMap) {
+  const base = {
+    bitwarden_id: item.id,
+    name: item.name,
+    type: TYPE_MAP[item.type] || 'unknown',
+    notes: item.notes || null,
+    is_favorite: item.favorite || false,
+    folder_name: item.folderId ? (folderMap[item.folderId] || null) : null,
+    custom_fields: (item.fields || []).map(f => ({
+      name: f.name,
+      value: f.value,
+      is_hidden: f.type === FIELD_TYPE_HIDDEN,
+    })),
+    attachments: [],
+    // Migration state (defaults)
+    disposition: null,
+    user_notes: '',
+    is_pinned: false,
+    field_statuses: {
+      totp: null,
+      notes: null,
+      custom_fields: [],
+      attachments: [],
+    },
+  };
+
+  // Login fields
+  base.uris = [];
+  base.username = null;
+  base.password = null;
+  base.totp = null;
+  if (item.type === 1 && item.login) {
+    base.uris = (item.login.uris || []).map(u => ({ uri: u.uri }));
+    base.username = item.login.username || null;
+    base.password = item.login.password || null;
+    base.totp = item.login.totp || null;
+  }
+
+  // Card fields
+  base.cardholder_name = null;
+  base.card_brand = null;
+  base.card_number = null;
+  base.card_exp_month = null;
+  base.card_exp_year = null;
+  base.card_code = null;
+  if (item.type === 3 && item.card) {
+    base.cardholder_name = item.card.cardholderName || null;
+    base.card_brand = item.card.brand || null;
+    base.card_number = item.card.number || null;
+    base.card_exp_month = item.card.expMonth || null;
+    base.card_exp_year = item.card.expYear || null;
+    base.card_code = item.card.code || null;
+  }
+
+  // Identity fields
+  base.identity_title = null;
+  base.identity_first_name = null;
+  base.identity_last_name = null;
+  base.identity_email = null;
+  base.identity_phone = null;
+  base.identity_address = null;
+  if (item.type === 4 && item.identity) {
+    const id = item.identity;
+    base.identity_title = id.title || null;
+    base.identity_first_name = id.firstName || null;
+    base.identity_last_name = id.lastName || null;
+    base.identity_email = id.email || null;
+    base.identity_phone = id.phone || null;
+    base.identity_address = [id.address1, id.address2, id.address3, id.city, id.state, id.postalCode, id.country]
+      .filter(Boolean)
+      .join(', ') || null;
+  }
+
+  // Initialize field_statuses arrays to match custom_fields length
+  base.field_statuses.custom_fields = base.custom_fields.map(() => null);
+
+  return base;
+}
+
+export async function parseZipExport(zipFile) {
+  const JSZip = (await import('jszip')).default;
+  const zip = await JSZip.loadAsync(zipFile);
+
+  const dataFile = zip.file('data.json');
+  if (!dataFile) throw new Error('No data.json found in zip');
+
+  const dataJson = await dataFile.async('string');
+  const data = JSON.parse(dataJson);
+
+  const folderMap = mapFolders(data.folders || []);
+  const entries = (data.items || []).map(item => parseBitwardenItem(item, folderMap));
+
+  // Load attachments
+  for (const entry of entries) {
+    const itemAttachments = (data.items.find(i => i.id === entry.bitwarden_id)?.attachments) || [];
+    for (const att of itemAttachments) {
+      const attFile = zip.file(att.fileName);
+      let content = null;
+      let is_binary = false;
+      if (attFile) {
+        try {
+          content = await attFile.async('string');
+          // Check if content looks binary
+          if (/[\x00-\x08\x0E-\x1F]/.test(content.substring(0, 1000))) {
+            content = null;
+            is_binary = true;
+          }
+        } catch {
+          is_binary = true;
+        }
+      }
+      entry.attachments.push({ filename: att.fileName, content, is_binary });
+    }
+    entry.field_statuses.attachments = entry.attachments.map(() => null);
+  }
+
+  return entries;
+}
+```
+
+**Step 5: Run tests to verify they pass**
+
+Run: `npm test -- src/pages/tools/password-migration/_app/parser.test.js`
+Expected: PASS (all 5 tests)
+
+**Step 6: Commit**
+
+```bash
+git add package.json package-lock.json src/pages/tools/password-migration/_app/parser.js src/pages/tools/password-migration/_app/parser.test.js
+git commit -m "feat(password-migration): add Bitwarden export parser with tests"
+```
+
+---
+
+### Task 2: Build the hooks and state management
+
+**Files:**
+- Create: `src/pages/tools/password-migration/_app/hooks.js`
+- Test: `src/pages/tools/password-migration/_app/hooks.test.js`
+
+**Step 1: Write failing tests for hooks**
+
+```js
+// hooks.test.js
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLocalStorage } from './hooks.js';
+
+beforeEach(() => localStorage.clear());
+
+describe('useLocalStorage', () => {
+  it('returns initial value when nothing stored', () => {
+    const { result } = renderHook(() => useLocalStorage('key', 'default'));
+    expect(result.current[0]).toBe('default');
+  });
+
+  it('persists value to localStorage', () => {
+    const { result } = renderHook(() => useLocalStorage('key', 'default'));
+    act(() => result.current[1]('updated'));
+    expect(result.current[0]).toBe('updated');
+    expect(JSON.parse(localStorage.getItem('passwordMigration_key'))).toBe('updated');
+  });
+
+  it('reads existing value from localStorage', () => {
+    localStorage.setItem('passwordMigration_key', JSON.stringify('stored'));
+    const { result } = renderHook(() => useLocalStorage('key', 'default'));
+    expect(result.current[0]).toBe('stored');
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/pages/tools/password-migration/_app/hooks.test.js`
+Expected: FAIL
+
+**Step 3: Implement hooks**
+
+```js
+// hooks.js
+import { useState, useEffect } from 'react';
+
+const STORAGE_PREFIX = 'passwordMigration_';
+
+export function useLocalStorage(key, initialValue) {
+  const fullKey = STORAGE_PREFIX + key;
+  const [value, setValue] = useState(() => {
+    try {
+      const stored = localStorage.getItem(fullKey);
+      return stored !== null ? JSON.parse(stored) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    localStorage.setItem(fullKey, JSON.stringify(value));
+  }, [fullKey, value]);
+
+  return [value, setValue];
+}
+
+export function clearAllStorage() {
+  const keys = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key.startsWith(STORAGE_PREFIX)) keys.push(key);
+  }
+  keys.forEach(k => localStorage.removeItem(k));
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npm test -- src/pages/tools/password-migration/_app/hooks.test.js`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/pages/tools/password-migration/_app/hooks.js src/pages/tools/password-migration/_app/hooks.test.js
+git commit -m "feat(password-migration): add localStorage hooks and state management"
+```
+
+---
+
+### Task 3: Build the UploadView component
+
+**Files:**
+- Create: `src/pages/tools/password-migration/_app/components/UploadView.jsx`
+- Test: `src/pages/tools/password-migration/_app/components/UploadView.test.jsx`
+
+**Step 1: Write failing test**
+
+```jsx
+// UploadView.test.jsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { UploadView } from './UploadView.jsx';
+
+describe('UploadView', () => {
+  it('renders upload prompt', () => {
+    render(<UploadView onImport={vi.fn()} isLoading={false} error={null} />);
+    expect(screen.getByText(/upload.*bitwarden/i)).toBeInTheDocument();
+    expect(screen.getByText(/\.zip/i)).toBeInTheDocument();
+  });
+
+  it('shows loading state', () => {
+    render(<UploadView onImport={vi.fn()} isLoading={true} error={null} />);
+    expect(screen.getByText(/parsing/i)).toBeInTheDocument();
+  });
+
+  it('shows error message', () => {
+    render(<UploadView onImport={vi.fn()} isLoading={false} error="Bad zip" />);
+    expect(screen.getByText('Bad zip')).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/pages/tools/password-migration/_app/components/UploadView.test.jsx`
+Expected: FAIL
+
+**Step 3: Implement UploadView**
+
+```jsx
+// UploadView.jsx
+import React, { useCallback } from 'react';
+
+export function UploadView({ onImport, isLoading, error }) {
+  const handleFile = useCallback((e) => {
+    const file = e.target.files?.[0];
+    if (file) onImport(file);
+  }, [onImport]);
+
+  return (
+    <div className="max-w-xl mx-auto p-8 text-center">
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+        Password Migration Helper
+      </h1>
+      <p className="text-gray-600 dark:text-gray-400 mb-8">
+        Upload your Bitwarden .zip export to begin tracking your migration
+        to Apple Passwords and Uplock.
+      </p>
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded">
+          {error}
+        </div>
+      )}
+
+      {isLoading ? (
+        <p className="text-gray-500 dark:text-gray-400">Parsing export...</p>
+      ) : (
+        <label className="inline-block cursor-pointer px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+          Choose .zip file
+          <input
+            type="file"
+            accept=".zip"
+            onChange={handleFile}
+            className="hidden"
+          />
+        </label>
+      )}
+    </div>
+  );
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npm test -- src/pages/tools/password-migration/_app/components/UploadView.test.jsx`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/pages/tools/password-migration/_app/components/
+git commit -m "feat(password-migration): add UploadView component"
+```
+
+---
+
+### Task 4: Build the ProgressDashboard component
+
+**Files:**
+- Create: `src/pages/tools/password-migration/_app/components/ProgressDashboard.jsx`
+- Test: `src/pages/tools/password-migration/_app/components/ProgressDashboard.test.jsx`
+
+**Step 1: Write failing test**
+
+```jsx
+// ProgressDashboard.test.jsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ProgressDashboard } from './ProgressDashboard.jsx';
+
+describe('ProgressDashboard', () => {
+  const defaults = {
+    total: 580,
+    done: 200,
+    remaining: 380,
+    applePasswordsMarked: 150,
+    applePasswordsReported: null,
+    onApplePasswordsCountChange: vi.fn(),
+    onReset: vi.fn(),
+  };
+
+  it('shows progress counts', () => {
+    render(<ProgressDashboard {...defaults} />);
+    expect(screen.getByText(/200/)).toBeInTheDocument();
+    expect(screen.getByText(/580/)).toBeInTheDocument();
+    expect(screen.getByText(/380/)).toBeInTheDocument();
+  });
+
+  it('shows checksum delta when reported count entered', () => {
+    render(<ProgressDashboard {...defaults} applePasswordsReported={160} />);
+    expect(screen.getByText(/10/)).toBeInTheDocument(); // delta: 160 - 150
+  });
+
+  it('has a reset button', () => {
+    render(<ProgressDashboard {...defaults} />);
+    expect(screen.getByRole('button', { name: /reset/i })).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/pages/tools/password-migration/_app/components/ProgressDashboard.test.jsx`
+
+**Step 3: Implement ProgressDashboard**
+
+```jsx
+// ProgressDashboard.jsx
+import React, { useState } from 'react';
+
+export function ProgressDashboard({
+  total, done, remaining,
+  applePasswordsMarked, applePasswordsReported,
+  onApplePasswordsCountChange, onReset,
+}) {
+  const [showConfirm, setShowConfirm] = useState(false);
+  const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+  const delta = applePasswordsReported != null
+    ? applePasswordsReported - applePasswordsMarked
+    : null;
+
+  return (
+    <div className="mb-6 p-4 bg-white dark:bg-gray-800 rounded-lg shadow-sm">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+          Progress
+        </h2>
+        {showConfirm ? (
+          <div className="flex gap-2">
+            <span className="text-sm text-gray-600 dark:text-gray-400">Reset all data?</span>
+            <button onClick={() => { onReset(); setShowConfirm(false); }}
+              className="text-sm px-2 py-1 bg-red-600 text-white rounded">
+              Confirm
+            </button>
+            <button onClick={() => setShowConfirm(false)}
+              className="text-sm px-2 py-1 bg-gray-300 dark:bg-gray-600 rounded">
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button onClick={() => setShowConfirm(true)}
+            className="text-sm text-red-600 dark:text-red-400 hover:underline">
+            Reset
+          </button>
+        )}
+      </div>
+
+      {/* Progress bar */}
+      <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-3 mb-2">
+        <div className="bg-green-500 h-3 rounded-full transition-all"
+          style={{ width: `${pct}%` }} />
+      </div>
+
+      <div className="flex gap-6 text-sm text-gray-600 dark:text-gray-400 mb-3">
+        <span><strong className="text-gray-900 dark:text-gray-100">{done}</strong> done</span>
+        <span><strong className="text-gray-900 dark:text-gray-100">{remaining}</strong> remaining</span>
+        <span><strong className="text-gray-900 dark:text-gray-100">{total}</strong> total</span>
+      </div>
+
+      {/* Apple Passwords checksum */}
+      <div className="flex items-center gap-3 text-sm">
+        <label className="text-gray-600 dark:text-gray-400">
+          Apple Passwords count:
+          <input
+            type="number"
+            value={applePasswordsReported ?? ''}
+            onChange={e => onApplePasswordsCountChange(
+              e.target.value === '' ? null : parseInt(e.target.value, 10)
+            )}
+            className="ml-2 w-20 px-2 py-1 border rounded dark:bg-gray-700 dark:border-gray-600"
+            placeholder="..."
+          />
+        </label>
+        <span className="text-gray-500 dark:text-gray-500">
+          Marked: {applePasswordsMarked}
+        </span>
+        {delta != null && (
+          <span className={delta === 0 ? 'text-green-600' : 'text-amber-600'}>
+            Delta: {delta > 0 ? '+' : ''}{delta}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npm test -- src/pages/tools/password-migration/_app/components/ProgressDashboard.test.jsx`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/pages/tools/password-migration/_app/components/ProgressDashboard.jsx src/pages/tools/password-migration/_app/components/ProgressDashboard.test.jsx
+git commit -m "feat(password-migration): add ProgressDashboard component"
+```
+
+---
+
+### Task 5: Build the EntryList component with search/filter
+
+**Files:**
+- Create: `src/pages/tools/password-migration/_app/components/EntryList.jsx`
+- Test: `src/pages/tools/password-migration/_app/components/EntryList.test.jsx`
+
+**Step 1: Write failing test**
+
+```jsx
+// EntryList.test.jsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { EntryList } from './EntryList.jsx';
+
+const makeEntry = (overrides) => ({
+  bitwarden_id: 'id-1',
+  name: 'GitHub',
+  type: 'login',
+  uris: [{ uri: 'https://github.com' }],
+  disposition: null,
+  is_pinned: false,
+  folder_name: 'Dev',
+  custom_fields: [],
+  attachments: [],
+  totp: null,
+  ...overrides,
+});
+
+describe('EntryList', () => {
+  it('renders active entries', () => {
+    const entries = [makeEntry()];
+    render(<EntryList entries={entries} onPin={vi.fn()} />);
+    expect(screen.getByText('GitHub')).toBeInTheDocument();
+    expect(screen.getByText('Dev')).toBeInTheDocument();
+  });
+
+  it('separates done entries', () => {
+    const entries = [
+      makeEntry({ bitwarden_id: '1', name: 'Active', disposition: null }),
+      makeEntry({ bitwarden_id: '2', name: 'Done', disposition: 'apple_passwords' }),
+    ];
+    render(<EntryList entries={entries} onPin={vi.fn()} />);
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText('Done')).toBeInTheDocument();
+  });
+
+  it('filters by search text', () => {
+    const entries = [
+      makeEntry({ bitwarden_id: '1', name: 'GitHub' }),
+      makeEntry({ bitwarden_id: '2', name: 'Gmail' }),
+    ];
+    render(<EntryList entries={entries} onPin={vi.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: 'git' } });
+    expect(screen.getByText('GitHub')).toBeInTheDocument();
+    expect(screen.queryByText('Gmail')).not.toBeInTheDocument();
+  });
+
+  it('filters by type', () => {
+    const entries = [
+      makeEntry({ bitwarden_id: '1', name: 'Login Item', type: 'login' }),
+      makeEntry({ bitwarden_id: '2', name: 'Note Item', type: 'secure_note' }),
+    ];
+    render(<EntryList entries={entries} onPin={vi.fn()} />);
+    fireEvent.change(screen.getByDisplayValue('All types'), { target: { value: 'secure_note' } });
+    expect(screen.queryByText('Login Item')).not.toBeInTheDocument();
+    expect(screen.getByText('Note Item')).toBeInTheDocument();
+  });
+
+  it('calls onPin when clicking an entry', () => {
+    const onPin = vi.fn();
+    render(<EntryList entries={[makeEntry()]} onPin={onPin} />);
+    fireEvent.click(screen.getByText('GitHub'));
+    expect(onPin).toHaveBeenCalledWith('id-1');
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/pages/tools/password-migration/_app/components/EntryList.test.jsx`
+
+**Step 3: Implement EntryList**
+
+```jsx
+// EntryList.jsx
+import React, { useState, useMemo } from 'react';
+
+const TYPE_LABELS = {
+  login: 'Login',
+  secure_note: 'Note',
+  card: 'Card',
+  identity: 'Identity',
+};
+
+const DISPOSITION_LABELS = {
+  apple_passwords: 'Apple Passwords',
+  uplock: 'Uplock',
+  apple_wallet: 'Apple Wallet',
+  deleted: 'Deleted',
+};
+
+function EntryRow({ entry, onPin }) {
+  const hasExtras = entry.custom_fields.length > 0 || entry.totp || entry.attachments.length > 0;
+  const isDone = entry.disposition != null;
+
+  return (
+    <div
+      onClick={() => onPin(entry.bitwarden_id)}
+      className={`flex items-center justify-between px-3 py-2 rounded cursor-pointer transition-colors ${
+        entry.is_pinned
+          ? 'bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800'
+          : isDone
+            ? 'opacity-50 hover:opacity-70'
+            : 'hover:bg-gray-100 dark:hover:bg-gray-700/50'
+      }`}
+    >
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="text-xs px-1.5 py-0.5 rounded bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400 shrink-0">
+          {TYPE_LABELS[entry.type] || entry.type}
+        </span>
+        <span className="text-gray-900 dark:text-gray-100 truncate">{entry.name}</span>
+        {entry.folder_name && (
+          <span className="text-xs text-gray-400 dark:text-gray-500 shrink-0">
+            {entry.folder_name}
+          </span>
+        )}
+        {hasExtras && (
+          <span className="text-xs text-amber-500 shrink-0" title="Has extra fields">*</span>
+        )}
+      </div>
+      {isDone && (
+        <span className="text-xs text-green-600 dark:text-green-400 shrink-0 ml-2">
+          {DISPOSITION_LABELS[entry.disposition]}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function EntryList({ entries, onPin }) {
+  const [search, setSearch] = useState('');
+  const [typeFilter, setTypeFilter] = useState('');
+
+  const filtered = useMemo(() => {
+    let result = entries;
+    if (search) {
+      const q = search.toLowerCase();
+      result = result.filter(e =>
+        e.name.toLowerCase().includes(q) ||
+        e.uris?.some(u => u.uri.toLowerCase().includes(q))
+      );
+    }
+    if (typeFilter) {
+      result = result.filter(e => e.type === typeFilter);
+    }
+    return result;
+  }, [entries, search, typeFilter]);
+
+  const active = filtered.filter(e => e.disposition == null);
+  const done = filtered.filter(e => e.disposition != null);
+
+  // Pinned entry first
+  active.sort((a, b) => (b.is_pinned ? 1 : 0) - (a.is_pinned ? 1 : 0));
+
+  return (
+    <div>
+      <div className="flex gap-2 mb-3">
+        <input
+          type="text"
+          placeholder="Search entries..."
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          className="flex-1 px-3 py-2 border rounded dark:bg-gray-800 dark:border-gray-600 text-sm"
+        />
+        <select
+          value={typeFilter}
+          onChange={e => setTypeFilter(e.target.value)}
+          className="px-3 py-2 border rounded dark:bg-gray-800 dark:border-gray-600 text-sm"
+        >
+          <option value="">All types</option>
+          <option value="login">Login</option>
+          <option value="secure_note">Note</option>
+          <option value="card">Card</option>
+          <option value="identity">Identity</option>
+        </select>
+      </div>
+
+      <div className="space-y-1">
+        {active.map(entry => (
+          <EntryRow key={entry.bitwarden_id} entry={entry} onPin={onPin} />
+        ))}
+      </div>
+
+      {done.length > 0 && (
+        <>
+          <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400 mt-6 mb-2">
+            Done ({done.length})
+          </h3>
+          <div className="space-y-1">
+            {done.map(entry => (
+              <EntryRow key={entry.bitwarden_id} entry={entry} onPin={onPin} />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npm test -- src/pages/tools/password-migration/_app/components/EntryList.test.jsx`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/pages/tools/password-migration/_app/components/EntryList.jsx src/pages/tools/password-migration/_app/components/EntryList.test.jsx
+git commit -m "feat(password-migration): add EntryList with search and filter"
+```
+
+---
+
+### Task 6: Build the EntryDetail component
+
+**Files:**
+- Create: `src/pages/tools/password-migration/_app/components/EntryDetail.jsx`
+- Test: `src/pages/tools/password-migration/_app/components/EntryDetail.test.jsx`
+
+**Step 1: Write failing test**
+
+```jsx
+// EntryDetail.test.jsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { EntryDetail } from './EntryDetail.jsx';
+
+const makeEntry = (overrides) => ({
+  bitwarden_id: 'id-1',
+  name: 'GitHub',
+  type: 'login',
+  uris: [{ uri: 'https://github.com' }],
+  username: 'user@example.com',
+  password: 'secret',
+  totp: 'otpauth://totp/secret',
+  notes: 'Some notes',
+  folder_name: 'Dev',
+  custom_fields: [
+    { name: 'API Key', value: 'key-123', is_hidden: true },
+  ],
+  attachments: [
+    { filename: 'backup.txt', content: 'code1 code2', is_binary: false },
+  ],
+  disposition: null,
+  user_notes: '',
+  is_pinned: true,
+  field_statuses: {
+    totp: null,
+    notes: null,
+    custom_fields: [null],
+    attachments: [null],
+  },
+  ...overrides,
+});
+
+describe('EntryDetail', () => {
+  const handlers = {
+    onSetDisposition: vi.fn(),
+    onClearDisposition: vi.fn(),
+    onUnpin: vi.fn(),
+    onUpdateNotes: vi.fn(),
+    onSetFieldStatus: vi.fn(),
+  };
+
+  it('shows entry name and type', () => {
+    render(<EntryDetail entry={makeEntry()} {...handlers} />);
+    expect(screen.getByText('GitHub')).toBeInTheDocument();
+    expect(screen.getByText(/login/i)).toBeInTheDocument();
+  });
+
+  it('hides password behind reveal toggle', () => {
+    render(<EntryDetail entry={makeEntry()} {...handlers} />);
+    expect(screen.queryByText('secret')).not.toBeInTheDocument();
+    fireEvent.click(screen.getAllByTitle(/reveal/i)[0]);
+    expect(screen.getByText('secret')).toBeInTheDocument();
+  });
+
+  it('shows disposition buttons', () => {
+    render(<EntryDetail entry={makeEntry()} {...handlers} />);
+    expect(screen.getByRole('button', { name: /apple passwords/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /uplock/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /deleted/i })).toBeInTheDocument();
+  });
+
+  it('calls onSetDisposition when clicking a disposition', () => {
+    render(<EntryDetail entry={makeEntry()} {...handlers} />);
+    fireEvent.click(screen.getByRole('button', { name: /apple passwords/i }));
+    expect(handlers.onSetDisposition).toHaveBeenCalledWith('id-1', 'apple_passwords');
+  });
+
+  it('shows folder name', () => {
+    render(<EntryDetail entry={makeEntry()} {...handlers} />);
+    expect(screen.getByText('Dev')).toBeInTheDocument();
+  });
+
+  it('shows field status toggles for custom fields', () => {
+    render(<EntryDetail entry={makeEntry()} {...handlers} />);
+    expect(screen.getByText('API Key')).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/pages/tools/password-migration/_app/components/EntryDetail.test.jsx`
+
+**Step 3: Implement EntryDetail**
+
+```jsx
+// EntryDetail.jsx
+import React, { useState } from 'react';
+
+function RevealField({ label, value, multiline }) {
+  const [revealed, setRevealed] = useState(false);
+  if (!value) return null;
+
+  return (
+    <div className="flex items-start gap-2">
+      <span className="text-sm text-gray-500 dark:text-gray-400 w-28 shrink-0">{label}</span>
+      {revealed ? (
+        <div className="flex-1">
+          {multiline ? (
+            <pre className="text-sm text-gray-900 dark:text-gray-100 whitespace-pre-wrap font-mono bg-gray-50 dark:bg-gray-900 p-2 rounded">{value}</pre>
+          ) : (
+            <span className="text-sm text-gray-900 dark:text-gray-100 font-mono">{value}</span>
+          )}
+          <button onClick={() => setRevealed(false)}
+            className="ml-2 text-xs text-gray-400 hover:text-gray-600" title="Hide">
+            hide
+          </button>
+        </div>
+      ) : (
+        <button onClick={() => setRevealed(true)}
+          className="text-sm text-blue-600 dark:text-blue-400 hover:underline" title="Reveal">
+          Click to reveal
+        </button>
+      )}
+    </div>
+  );
+}
+
+function PlainField({ label, value }) {
+  if (!value) return null;
+  return (
+    <div className="flex items-start gap-2">
+      <span className="text-sm text-gray-500 dark:text-gray-400 w-28 shrink-0">{label}</span>
+      <span className="text-sm text-gray-900 dark:text-gray-100">{value}</span>
+    </div>
+  );
+}
+
+function FieldStatusToggle({ label, status, onToggle }) {
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <select
+        value={status || ''}
+        onChange={e => onToggle(e.target.value || null)}
+        className="px-2 py-1 border rounded text-xs dark:bg-gray-700 dark:border-gray-600"
+      >
+        <option value="">Untracked</option>
+        <option value="migrated">Migrated</option>
+        <option value="discarded">Discarded</option>
+      </select>
+      <span className="text-gray-700 dark:text-gray-300">{label}</span>
+    </div>
+  );
+}
+
+const DISPOSITIONS = [
+  { value: 'apple_passwords', label: 'Apple Passwords' },
+  { value: 'uplock', label: 'Uplock' },
+  { value: 'apple_wallet', label: 'Apple Wallet' },
+  { value: 'deleted', label: 'Deleted' },
+];
+
+export function EntryDetail({
+  entry, onSetDisposition, onClearDisposition, onUnpin, onUpdateNotes, onSetFieldStatus,
+}) {
+  return (
+    <div className="mb-4 p-4 bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-blue-200 dark:border-blue-800">
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{entry.name}</h2>
+          <div className="flex gap-2 text-xs text-gray-500 dark:text-gray-400">
+            <span className="px-1.5 py-0.5 rounded bg-gray-200 dark:bg-gray-700">
+              {entry.type}
+            </span>
+            {entry.folder_name && <span>{entry.folder_name}</span>}
+          </div>
+        </div>
+        <button onClick={onUnpin}
+          className="text-sm text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+          Close
+        </button>
+      </div>
+
+      {/* Bitwarden fields */}
+      <div className="space-y-2 mb-4">
+        {entry.uris?.map((u, i) => (
+          <PlainField key={i} label={i === 0 ? 'URL' : `URL ${i + 1}`} value={u.uri} />
+        ))}
+        <PlainField label="Username" value={entry.username} />
+        <RevealField label="Password" value={entry.password} />
+        <RevealField label="TOTP" value={entry.totp} />
+        <PlainField label="Notes" value={entry.notes} />
+
+        {/* Card fields */}
+        <PlainField label="Cardholder" value={entry.cardholder_name} />
+        <PlainField label="Brand" value={entry.card_brand} />
+        <RevealField label="Card Number" value={entry.card_number} />
+        <PlainField label="Expires" value={
+          entry.card_exp_month && entry.card_exp_year
+            ? `${entry.card_exp_month}/${entry.card_exp_year}` : null
+        } />
+        <RevealField label="CVV" value={entry.card_code} />
+
+        {/* Identity fields */}
+        <PlainField label="Title" value={entry.identity_title} />
+        <PlainField label="Name" value={
+          [entry.identity_first_name, entry.identity_last_name].filter(Boolean).join(' ') || null
+        } />
+        <PlainField label="Email" value={entry.identity_email} />
+        <PlainField label="Phone" value={entry.identity_phone} />
+        <PlainField label="Address" value={entry.identity_address} />
+      </div>
+
+      {/* Custom fields */}
+      {entry.custom_fields.length > 0 && (
+        <div className="mb-4">
+          <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Custom Fields</h3>
+          <div className="space-y-2">
+            {entry.custom_fields.map((f, i) => (
+              <div key={i} className="flex items-center gap-3">
+                {f.is_hidden ? (
+                  <RevealField label={f.name} value={f.value} />
+                ) : (
+                  <PlainField label={f.name} value={f.value} />
+                )}
+                <FieldStatusToggle
+                  label=""
+                  status={entry.field_statuses.custom_fields[i]}
+                  onToggle={v => onSetFieldStatus(entry.bitwarden_id, `custom_field_${i}`, v)}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Attachments */}
+      {entry.attachments.length > 0 && (
+        <div className="mb-4">
+          <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Attachments</h3>
+          <div className="space-y-2">
+            {entry.attachments.map((a, i) => (
+              <div key={i} className="flex items-center gap-3">
+                {a.is_binary ? (
+                  <PlainField label={a.filename} value="(binary file)" />
+                ) : (
+                  <RevealField label={a.filename} value={a.content} multiline />
+                )}
+                <FieldStatusToggle
+                  label=""
+                  status={entry.field_statuses.attachments[i]}
+                  onToggle={v => onSetFieldStatus(entry.bitwarden_id, `attachment_${i}`, v)}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* TOTP and Notes field tracking */}
+      {(entry.totp || entry.notes) && (
+        <div className="mb-4 space-y-2">
+          {entry.totp && (
+            <FieldStatusToggle
+              label="TOTP code"
+              status={entry.field_statuses.totp}
+              onToggle={v => onSetFieldStatus(entry.bitwarden_id, 'totp', v)}
+            />
+          )}
+          {entry.notes && (
+            <FieldStatusToggle
+              label="Notes"
+              status={entry.field_statuses.notes}
+              onToggle={v => onSetFieldStatus(entry.bitwarden_id, 'notes', v)}
+            />
+          )}
+        </div>
+      )}
+
+      {/* Disposition */}
+      <div className="mb-4">
+        <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Destination</h3>
+        <div className="flex flex-wrap gap-2">
+          {DISPOSITIONS.map(d => (
+            <button key={d.value}
+              onClick={() => entry.disposition === d.value
+                ? onClearDisposition(entry.bitwarden_id)
+                : onSetDisposition(entry.bitwarden_id, d.value)
+              }
+              className={`px-3 py-1.5 text-sm rounded transition-colors ${
+                entry.disposition === d.value
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
+              }`}
+            >
+              {d.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* User notes */}
+      <div>
+        <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Your Notes</h3>
+        <textarea
+          value={entry.user_notes}
+          onChange={e => onUpdateNotes(entry.bitwarden_id, e.target.value)}
+          placeholder="Add notes about this entry..."
+          rows={2}
+          className="w-full px-3 py-2 border rounded text-sm dark:bg-gray-700 dark:border-gray-600"
+        />
+      </div>
+    </div>
+  );
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npm test -- src/pages/tools/password-migration/_app/components/EntryDetail.test.jsx`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/pages/tools/password-migration/_app/components/EntryDetail.jsx src/pages/tools/password-migration/_app/components/EntryDetail.test.jsx
+git commit -m "feat(password-migration): add EntryDetail with reveal, disposition, field tracking"
+```
+
+---
+
+### Task 7: Wire everything together in App
+
+**Files:**
+- Modify: `src/pages/tools/password-migration/_app/app.jsx`
+- Modify: `src/pages/tools/password-migration/_app/app.css`
+
+**Step 1: Replace the skeleton app.jsx**
+
+```jsx
+// app.jsx
+import React, { useState, useCallback, useMemo } from 'react';
+import { createRoot } from 'react-dom/client';
+import { useLocalStorage, clearAllStorage } from './hooks.js';
+import { parseZipExport } from './parser.js';
+import { UploadView } from './components/UploadView.jsx';
+import { ProgressDashboard } from './components/ProgressDashboard.jsx';
+import { EntryList } from './components/EntryList.jsx';
+import { EntryDetail } from './components/EntryDetail.jsx';
+import './app.css';
+
+const App = () => {
+  const [entries, setEntries] = useLocalStorage('entries', null);
+  const [applePasswordsReported, setApplePasswordsReported] = useLocalStorage('applePasswordsReported', null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleImport = useCallback(async (file) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const parsed = await parseZipExport(file);
+      setEntries(parsed);
+    } catch (e) {
+      setError(e.message || 'Failed to parse export');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [setEntries]);
+
+  const handleReset = useCallback(() => {
+    clearAllStorage();
+    setEntries(null);
+    setApplePasswordsReported(null);
+  }, [setEntries, setApplePasswordsReported]);
+
+  const updateEntry = useCallback((id, updater) => {
+    setEntries(prev => prev.map(e =>
+      e.bitwarden_id === id ? updater(e) : e
+    ));
+  }, [setEntries]);
+
+  const handlePin = useCallback((id) => {
+    setEntries(prev => prev.map(e => ({
+      ...e,
+      is_pinned: e.bitwarden_id === id ? !e.is_pinned : false,
+    })));
+  }, [setEntries]);
+
+  const handleSetDisposition = useCallback((id, disposition) => {
+    updateEntry(id, e => ({ ...e, disposition }));
+  }, [updateEntry]);
+
+  const handleClearDisposition = useCallback((id) => {
+    updateEntry(id, e => ({ ...e, disposition: null }));
+  }, [updateEntry]);
+
+  const handleUnpin = useCallback(() => {
+    setEntries(prev => prev.map(e => ({ ...e, is_pinned: false })));
+  }, [setEntries]);
+
+  const handleUpdateNotes = useCallback((id, text) => {
+    updateEntry(id, e => ({ ...e, user_notes: text }));
+  }, [updateEntry]);
+
+  const handleSetFieldStatus = useCallback((id, fieldName, status) => {
+    updateEntry(id, e => {
+      const fs = { ...e.field_statuses };
+      if (fieldName === 'totp') {
+        fs.totp = status;
+      } else if (fieldName === 'notes') {
+        fs.notes = status;
+      } else if (fieldName.startsWith('custom_field_')) {
+        const idx = parseInt(fieldName.split('_')[2], 10);
+        fs.custom_fields = [...fs.custom_fields];
+        fs.custom_fields[idx] = status;
+      } else if (fieldName.startsWith('attachment_')) {
+        const idx = parseInt(fieldName.split('_')[1], 10);
+        fs.attachments = [...fs.attachments];
+        fs.attachments[idx] = status;
+      }
+      return { ...e, field_statuses: fs };
+    });
+  }, [updateEntry]);
+
+  // Show upload view if no entries loaded
+  if (!entries) {
+    return <UploadView onImport={handleImport} isLoading={isLoading} error={error} />;
+  }
+
+  const total = entries.length;
+  const done = entries.filter(e => e.disposition != null).length;
+  const remaining = total - done;
+  const applePasswordsMarked = entries.filter(e => e.disposition === 'apple_passwords').length;
+  const pinnedEntry = entries.find(e => e.is_pinned);
+
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+        Password Migration Helper
+      </h1>
+
+      <ProgressDashboard
+        total={total}
+        done={done}
+        remaining={remaining}
+        applePasswordsMarked={applePasswordsMarked}
+        applePasswordsReported={applePasswordsReported}
+        onApplePasswordsCountChange={setApplePasswordsReported}
+        onReset={handleReset}
+      />
+
+      {pinnedEntry && (
+        <EntryDetail
+          entry={pinnedEntry}
+          onSetDisposition={handleSetDisposition}
+          onClearDisposition={handleClearDisposition}
+          onUnpin={handleUnpin}
+          onUpdateNotes={handleUpdateNotes}
+          onSetFieldStatus={handleSetFieldStatus}
+        />
+      )}
+
+      <EntryList entries={entries} onPin={handlePin} />
+    </div>
+  );
+};
+
+createRoot(document.getElementById('app')).render(<App />);
+```
+
+**Step 2: Verify app.css is correct (already has `@import "tailwindcss";`)**
+
+No change needed.
+
+**Step 3: Run all tests**
+
+Run: `npm test -- src/pages/tools/password-migration/`
+Expected: All tests pass
+
+**Step 4: Run dev server and manually test**
+
+Run: `npm run dev`
+Visit: `http://localhost:4321/tools/password-migration/`
+Verify: Upload screen appears. After uploading a Bitwarden zip, entries load and you can pin, set disposition, track fields, search, filter, reset.
+
+**Step 5: Build for production**
+
+Run: `npm run build`
+Expected: Build succeeds
+
+**Step 6: Commit**
+
+```bash
+git add src/pages/tools/password-migration/_app/app.jsx src/pages/tools/password-migration/_app/app.css
+git commit -m "feat(password-migration): wire up all components in main App"
+```
+
+---
+
+### Task 8: Update content metadata
+
+**Files:**
+- Modify: `src/content/tools/password-migration.json`
+
+**Step 1: Update the description**
+
+```json
+{
+  "title": "Password Migration Helper",
+  "date": "2026-03-07",
+  "description": "Audit and track migration of a Bitwarden vault to Apple Passwords and Uplock."
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/content/tools/password-migration.json
+git commit -m "chore(password-migration): update tool description"
+```
+
+---
+
+## Summary
+
+| Task | What | Files |
+|------|------|-------|
+| 1 | Parser (Bitwarden JSON + zip) | `parser.js`, `parser.test.js` |
+| 2 | Hooks (localStorage, clearAll) | `hooks.js`, `hooks.test.js` |
+| 3 | UploadView | `components/UploadView.jsx`, `.test.jsx` |
+| 4 | ProgressDashboard | `components/ProgressDashboard.jsx`, `.test.jsx` |
+| 5 | EntryList (search, filter, active/done) | `components/EntryList.jsx`, `.test.jsx` |
+| 6 | EntryDetail (reveal, disposition, field tracking) | `components/EntryDetail.jsx`, `.test.jsx` |
+| 7 | Wire everything in App | `app.jsx` |
+| 8 | Update content metadata | `password-migration.json` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@vitejs/plugin-react": "^5.1.4",
         "ably": "^2.17.1",
         "astro": "^5.16.15",
+        "jszip": "^3.10.1",
         "qrcode": "^1.5.4",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -3343,6 +3344,12 @@
       "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==",
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/crossws": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
@@ -4147,7 +4154,6 @@
       "integrity": "sha512-hR/uLYQdngTyEfxnOoa+e6KTcfBFyc1hgFj/Cc144A5JJUuHFYqIEBDcD4FeGqUeKLRZqJ9eN9u7/GDjYEgS1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -4440,6 +4446,12 @@
         "node": ">=10.19.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-meta-resolve": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
@@ -4459,6 +4471,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -4588,6 +4606,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -4645,6 +4669,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4661,6 +4697,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -6302,6 +6347,12 @@
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -6494,6 +6545,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -6599,6 +6656,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/readdirp": {
@@ -7083,6 +7155,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/sax": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
@@ -7115,6 +7193,12 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -7288,6 +7372,15 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/string-width": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@vitejs/plugin-react": "^5.1.4",
     "ably": "^2.17.1",
     "astro": "^5.16.15",
+    "jszip": "^3.10.1",
     "qrcode": "^1.5.4",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/src/content/tools/password-migration.json
+++ b/src/content/tools/password-migration.json
@@ -1,0 +1,5 @@
+{
+  "title": "Password Migration Helper",
+  "date": "2026-03-07",
+  "description": "Audit and track migration of a Bitwarden vault to Apple Passwords and Uplock."
+}

--- a/src/pages/tools/password-migration/_app/app.css
+++ b/src/pages/tools/password-migration/_app/app.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/src/pages/tools/password-migration/_app/app.jsx
+++ b/src/pages/tools/password-migration/_app/app.jsx
@@ -1,0 +1,127 @@
+import React, { useState, useCallback } from 'react';
+import { createRoot } from 'react-dom/client';
+import { useLocalStorage, clearAllStorage } from './hooks.js';
+import { parseZipExport } from './parser.js';
+import { UploadView } from './components/UploadView.jsx';
+import { ProgressDashboard } from './components/ProgressDashboard.jsx';
+import { EntryList } from './components/EntryList.jsx';
+import { EntryDetail } from './components/EntryDetail.jsx';
+import './app.css';
+
+const App = () => {
+  const [entries, setEntries] = useLocalStorage('entries', null);
+  const [applePasswordsReported, setApplePasswordsReported] = useLocalStorage('applePasswordsReported', null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleImport = useCallback(async (file) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const parsed = await parseZipExport(file);
+      setEntries(parsed);
+    } catch (e) {
+      setError(e.message || 'Failed to parse export');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [setEntries]);
+
+  const handleReset = useCallback(() => {
+    clearAllStorage();
+    setEntries(null);
+    setApplePasswordsReported(null);
+  }, [setEntries, setApplePasswordsReported]);
+
+  const updateEntry = useCallback((id, updater) => {
+    setEntries(prev => prev.map(e =>
+      e.bitwarden_id === id ? updater(e) : e
+    ));
+  }, [setEntries]);
+
+  const handlePin = useCallback((id) => {
+    setEntries(prev => prev.map(e => ({
+      ...e,
+      is_pinned: e.bitwarden_id === id ? !e.is_pinned : false,
+    })));
+  }, [setEntries]);
+
+  const handleSetDisposition = useCallback((id, disposition) => {
+    updateEntry(id, e => ({ ...e, disposition }));
+  }, [updateEntry]);
+
+  const handleClearDisposition = useCallback((id) => {
+    updateEntry(id, e => ({ ...e, disposition: null }));
+  }, [updateEntry]);
+
+  const handleUnpin = useCallback(() => {
+    setEntries(prev => prev.map(e => ({ ...e, is_pinned: false })));
+  }, [setEntries]);
+
+  const handleUpdateNotes = useCallback((id, text) => {
+    updateEntry(id, e => ({ ...e, user_notes: text }));
+  }, [updateEntry]);
+
+  const handleSetFieldStatus = useCallback((id, fieldName, status) => {
+    updateEntry(id, e => {
+      const fs = { ...e.field_statuses };
+      if (fieldName === 'totp') {
+        fs.totp = status;
+      } else if (fieldName === 'notes') {
+        fs.notes = status;
+      } else if (fieldName.startsWith('custom_field_')) {
+        const idx = parseInt(fieldName.split('_')[2], 10);
+        fs.custom_fields = [...fs.custom_fields];
+        fs.custom_fields[idx] = status;
+      } else if (fieldName.startsWith('attachment_')) {
+        const idx = parseInt(fieldName.split('_')[1], 10);
+        fs.attachments = [...fs.attachments];
+        fs.attachments[idx] = status;
+      }
+      return { ...e, field_statuses: fs };
+    });
+  }, [updateEntry]);
+
+  if (!entries) {
+    return <UploadView onImport={handleImport} isLoading={isLoading} error={error} />;
+  }
+
+  const total = entries.length;
+  const done = entries.filter(e => e.disposition != null).length;
+  const remaining = total - done;
+  const applePasswordsMarked = entries.filter(e => e.disposition === 'apple_passwords').length;
+  const pinnedEntry = entries.find(e => e.is_pinned);
+
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+        Password Migration Helper
+      </h1>
+
+      <ProgressDashboard
+        total={total}
+        done={done}
+        remaining={remaining}
+        applePasswordsMarked={applePasswordsMarked}
+        applePasswordsReported={applePasswordsReported}
+        onApplePasswordsCountChange={setApplePasswordsReported}
+        onReset={handleReset}
+      />
+
+      {pinnedEntry && (
+        <EntryDetail
+          entry={pinnedEntry}
+          onSetDisposition={handleSetDisposition}
+          onClearDisposition={handleClearDisposition}
+          onUnpin={handleUnpin}
+          onUpdateNotes={handleUpdateNotes}
+          onSetFieldStatus={handleSetFieldStatus}
+        />
+      )}
+
+      <EntryList entries={entries} onPin={handlePin} />
+    </div>
+  );
+};
+
+createRoot(document.getElementById('app')).render(<App />);

--- a/src/pages/tools/password-migration/_app/app.jsx
+++ b/src/pages/tools/password-migration/_app/app.jsx
@@ -94,17 +94,36 @@ const App = () => {
     setProgress(prev => ({ ...prev, applePasswordsReported: count }));
   }, [setProgress]);
 
+  const hasProgress = Object.keys(progress.dispositions).length > 0
+    || Object.keys(progress.userNotes).length > 0
+    || Object.keys(progress.fieldStatuses).length > 0;
+
   const backLink = (
     <a href="/tools/" className="text-sm text-blue-600 dark:text-blue-400 hover:underline mb-4 inline-block">
       &larr; Tools
     </a>
   );
 
+  // No vault loaded — either fresh start or returning with progress
   if (!entries) {
     return (
       <div className="max-w-xl mx-auto pt-8 px-8">
         {backLink}
+        {hasProgress && (
+          <div className="mb-6 p-4 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
+            <p className="text-sm text-amber-800 dark:text-amber-200 font-medium mb-1">
+              Migration in progress
+            </p>
+            <p className="text-sm text-amber-700 dark:text-amber-300">
+              Your progress is saved, but vault data has been cleared.
+              Re-upload your Bitwarden export to continue where you left off.
+            </p>
+          </div>
+        )}
         <UploadView onImport={handleImport} isLoading={isLoading} error={error} />
+        <p className="mt-6 text-xs text-gray-400 dark:text-gray-500 text-center">
+          Your progress is saved locally. Passwords are cleared when you close this tab.
+        </p>
       </div>
     );
   }

--- a/src/pages/tools/password-migration/_app/app.jsx
+++ b/src/pages/tools/password-migration/_app/app.jsx
@@ -5,7 +5,6 @@ import { parseZipExport } from './parser.js';
 import { UploadView } from './components/UploadView.jsx';
 import { ProgressDashboard } from './components/ProgressDashboard.jsx';
 import { EntryList } from './components/EntryList.jsx';
-import { EntryDetail } from './components/EntryDetail.jsx';
 import './app.css';
 
 const App = () => {
@@ -163,8 +162,6 @@ const App = () => {
   const done = entries.filter(e => e.disposition != null).length;
   const remaining = total - done;
   const applePasswordsMarked = entries.filter(e => e.disposition === 'apple_passwords').length;
-  const pinnedEntry = entries.find(e => e.is_pinned);
-
   return (
     <div className="max-w-3xl mx-auto p-4">
       {backLink}
@@ -206,18 +203,15 @@ const App = () => {
         onReset={handleReset}
       />
 
-      {pinnedEntry && (
-        <EntryDetail
-          entry={pinnedEntry}
-          onSetDisposition={handleSetDisposition}
-          onClearDisposition={handleClearDisposition}
-          onUnpin={handleUnpin}
-          onUpdateNotes={handleUpdateNotes}
-          onSetFieldStatus={handleSetFieldStatus}
-        />
-      )}
-
-      <EntryList entries={entries} onPin={handlePin} />
+      <EntryList
+        entries={entries}
+        onPin={handlePin}
+        onSetDisposition={handleSetDisposition}
+        onClearDisposition={handleClearDisposition}
+        onUnpin={handleUnpin}
+        onUpdateNotes={handleUpdateNotes}
+        onSetFieldStatus={handleSetFieldStatus}
+      />
     </div>
   );
 };

--- a/src/pages/tools/password-migration/_app/app.jsx
+++ b/src/pages/tools/password-migration/_app/app.jsx
@@ -20,30 +20,76 @@ const App = () => {
     try {
       const parsed = await parseZipExport(file);
       setVault(parsed);
+      // Save non-sensitive manifest for rendering without vault
+      const manifest = {};
+      for (const entry of parsed) {
+        manifest[entry.bitwarden_id] = {
+          name: entry.name,
+          type: entry.type,
+          folder_name: entry.folder_name,
+          has_totp: !!entry.totp,
+          has_notes: !!entry.notes,
+          custom_field_count: entry.custom_fields?.length || 0,
+          attachment_count: entry.attachments?.length || 0,
+        };
+      }
+      setProgress(prev => ({ ...prev, manifest }));
     } catch (e) {
       setError(e.message || 'Failed to parse export');
     } finally {
       setIsLoading(false);
     }
-  }, [setVault]);
+  }, [setVault, setProgress]);
 
   const handleReset = useCallback(() => {
     clearAll();
     setVault(null);
-    setProgress({ dispositions: {}, fieldStatuses: {}, userNotes: {}, pinnedId: null, applePasswordsReported: null });
+    setProgress({ manifest: {}, dispositions: {}, fieldStatuses: {}, userNotes: {}, pinnedId: null, applePasswordsReported: null });
   }, [setVault, setProgress]);
 
-  // Merge vault entries with progress data for rendering
+  const hasVault = !!vault;
+  const hasManifest = Object.keys(progress.manifest).length > 0;
+
+  // Build entries: full data if vault loaded, degraded if only manifest
   const entries = useMemo(() => {
-    if (!vault) return null;
-    return vault.map(entry => ({
-      ...entry,
-      disposition: progress.dispositions[entry.bitwarden_id] || null,
-      user_notes: progress.userNotes[entry.bitwarden_id] || '',
-      is_pinned: progress.pinnedId === entry.bitwarden_id,
-      field_statuses: progress.fieldStatuses[entry.bitwarden_id] || entry.field_statuses,
-    }));
-  }, [vault, progress]);
+    if (vault) {
+      return vault.map(entry => ({
+        ...entry,
+        disposition: progress.dispositions[entry.bitwarden_id] || null,
+        user_notes: progress.userNotes[entry.bitwarden_id] || '',
+        is_pinned: progress.pinnedId === entry.bitwarden_id,
+        field_statuses: progress.fieldStatuses[entry.bitwarden_id] || {},
+      }));
+    }
+    if (hasManifest) {
+      return Object.entries(progress.manifest).map(([id, meta]) => ({
+        bitwarden_id: id,
+        name: meta.name,
+        type: meta.type,
+        folder_name: meta.folder_name,
+        uris: [],
+        username: null,
+        password: null,
+        totp: meta.has_totp ? '(hidden)' : null,
+        notes: meta.has_notes ? '(hidden)' : null,
+        custom_fields: Array.from({ length: meta.custom_field_count }, (_, i) => ({
+          name: `Field ${i + 1}`, value: null, is_hidden: true,
+        })),
+        attachments: Array.from({ length: meta.attachment_count }, (_, i) => ({
+          filename: `Attachment ${i + 1}`, content: null, is_binary: false,
+        })),
+        cardholder_name: null, card_brand: null, card_number: null,
+        card_exp_month: null, card_exp_year: null, card_code: null,
+        identity_title: null, identity_first_name: null, identity_last_name: null,
+        identity_email: null, identity_phone: null, identity_address: null,
+        disposition: progress.dispositions[id] || null,
+        user_notes: progress.userNotes[id] || '',
+        is_pinned: progress.pinnedId === id,
+        field_statuses: progress.fieldStatuses[id] || {},
+      }));
+    }
+    return null;
+  }, [vault, progress, hasManifest]);
 
   const handlePin = useCallback((id) => {
     setProgress(prev => ({
@@ -94,32 +140,17 @@ const App = () => {
     setProgress(prev => ({ ...prev, applePasswordsReported: count }));
   }, [setProgress]);
 
-  const hasProgress = Object.keys(progress.dispositions).length > 0
-    || Object.keys(progress.userNotes).length > 0
-    || Object.keys(progress.fieldStatuses).length > 0;
-
   const backLink = (
     <a href="/tools/" className="text-sm text-blue-600 dark:text-blue-400 hover:underline mb-4 inline-block">
       &larr; Tools
     </a>
   );
 
-  // No vault loaded — either fresh start or returning with progress
+  // No data at all — fresh start
   if (!entries) {
     return (
       <div className="max-w-xl mx-auto pt-8 px-8">
         {backLink}
-        {hasProgress && (
-          <div className="mb-6 p-4 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
-            <p className="text-sm text-amber-800 dark:text-amber-200 font-medium mb-1">
-              Migration in progress
-            </p>
-            <p className="text-sm text-amber-700 dark:text-amber-300">
-              Your progress is saved, but vault data has been cleared.
-              Re-upload your Bitwarden export to continue where you left off.
-            </p>
-          </div>
-        )}
         <UploadView onImport={handleImport} isLoading={isLoading} error={error} />
         <p className="mt-6 text-xs text-gray-400 dark:text-gray-500 text-center">
           Your progress is saved locally. Passwords are cleared when you close this tab.
@@ -140,6 +171,30 @@ const App = () => {
       <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4">
         Password Migration Helper
       </h1>
+
+      {!hasVault && (
+        <div className="mb-4 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg flex items-center justify-between gap-4">
+          <p className="text-sm text-amber-700 dark:text-amber-300">
+            Sensitive data not loaded. Upload your Bitwarden export to view passwords and details.
+          </p>
+          <label className="shrink-0 cursor-pointer px-3 py-1.5 text-sm bg-amber-600 text-white rounded hover:bg-amber-700 transition-colors">
+            {isLoading ? 'Loading...' : 'Upload .zip'}
+            <input
+              type="file"
+              accept=".zip"
+              onChange={(e) => { const f = e.target.files?.[0]; if (f) handleImport(f); }}
+              className="hidden"
+              disabled={isLoading}
+            />
+          </label>
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded text-sm">
+          {error}
+        </div>
+      )}
 
       <ProgressDashboard
         total={total}

--- a/src/pages/tools/password-migration/_app/app.jsx
+++ b/src/pages/tools/password-migration/_app/app.jsx
@@ -82,8 +82,19 @@ const App = () => {
     });
   }, [updateEntry]);
 
+  const backLink = (
+    <a href="/tools/" className="text-sm text-blue-600 dark:text-blue-400 hover:underline mb-4 inline-block">
+      &larr; Tools
+    </a>
+  );
+
   if (!entries) {
-    return <UploadView onImport={handleImport} isLoading={isLoading} error={error} />;
+    return (
+      <div className="max-w-xl mx-auto pt-8 px-8">
+        {backLink}
+        <UploadView onImport={handleImport} isLoading={isLoading} error={error} />
+      </div>
+    );
   }
 
   const total = entries.length;
@@ -94,6 +105,7 @@ const App = () => {
 
   return (
     <div className="max-w-3xl mx-auto p-4">
+      {backLink}
       <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4">
         Password Migration Helper
       </h1>

--- a/src/pages/tools/password-migration/_app/app.jsx
+++ b/src/pages/tools/password-migration/_app/app.jsx
@@ -1,6 +1,6 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import { createRoot } from 'react-dom/client';
-import { useLocalStorage, clearAllStorage } from './hooks.js';
+import { useVault, useProgress, clearAll } from './hooks.js';
 import { parseZipExport } from './parser.js';
 import { UploadView } from './components/UploadView.jsx';
 import { ProgressDashboard } from './components/ProgressDashboard.jsx';
@@ -9,8 +9,8 @@ import { EntryDetail } from './components/EntryDetail.jsx';
 import './app.css';
 
 const App = () => {
-  const [entries, setEntries] = useLocalStorage('entries', null);
-  const [applePasswordsReported, setApplePasswordsReported] = useLocalStorage('applePasswordsReported', null);
+  const [vault, setVault] = useVault();
+  const [progress, setProgress] = useProgress();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
 
@@ -19,68 +19,80 @@ const App = () => {
     setError(null);
     try {
       const parsed = await parseZipExport(file);
-      setEntries(parsed);
+      setVault(parsed);
     } catch (e) {
       setError(e.message || 'Failed to parse export');
     } finally {
       setIsLoading(false);
     }
-  }, [setEntries]);
+  }, [setVault]);
 
   const handleReset = useCallback(() => {
-    clearAllStorage();
-    setEntries(null);
-    setApplePasswordsReported(null);
-  }, [setEntries, setApplePasswordsReported]);
+    clearAll();
+    setVault(null);
+    setProgress({ dispositions: {}, fieldStatuses: {}, userNotes: {}, pinnedId: null, applePasswordsReported: null });
+  }, [setVault, setProgress]);
 
-  const updateEntry = useCallback((id, updater) => {
-    setEntries(prev => prev.map(e =>
-      e.bitwarden_id === id ? updater(e) : e
-    ));
-  }, [setEntries]);
+  // Merge vault entries with progress data for rendering
+  const entries = useMemo(() => {
+    if (!vault) return null;
+    return vault.map(entry => ({
+      ...entry,
+      disposition: progress.dispositions[entry.bitwarden_id] || null,
+      user_notes: progress.userNotes[entry.bitwarden_id] || '',
+      is_pinned: progress.pinnedId === entry.bitwarden_id,
+      field_statuses: progress.fieldStatuses[entry.bitwarden_id] || entry.field_statuses,
+    }));
+  }, [vault, progress]);
 
   const handlePin = useCallback((id) => {
-    setEntries(prev => prev.map(e => ({
-      ...e,
-      is_pinned: e.bitwarden_id === id ? !e.is_pinned : false,
-    })));
-  }, [setEntries]);
+    setProgress(prev => ({
+      ...prev,
+      pinnedId: prev.pinnedId === id ? null : id,
+    }));
+  }, [setProgress]);
 
   const handleSetDisposition = useCallback((id, disposition) => {
-    updateEntry(id, e => ({ ...e, disposition }));
-  }, [updateEntry]);
+    setProgress(prev => ({
+      ...prev,
+      dispositions: { ...prev.dispositions, [id]: disposition },
+    }));
+  }, [setProgress]);
 
   const handleClearDisposition = useCallback((id) => {
-    updateEntry(id, e => ({ ...e, disposition: null }));
-  }, [updateEntry]);
+    setProgress(prev => {
+      const { [id]: _, ...rest } = prev.dispositions;
+      return { ...prev, dispositions: rest };
+    });
+  }, [setProgress]);
 
   const handleUnpin = useCallback(() => {
-    setEntries(prev => prev.map(e => ({ ...e, is_pinned: false })));
-  }, [setEntries]);
+    setProgress(prev => ({ ...prev, pinnedId: null }));
+  }, [setProgress]);
 
   const handleUpdateNotes = useCallback((id, text) => {
-    updateEntry(id, e => ({ ...e, user_notes: text }));
-  }, [updateEntry]);
+    setProgress(prev => ({
+      ...prev,
+      userNotes: { ...prev.userNotes, [id]: text },
+    }));
+  }, [setProgress]);
 
   const handleSetFieldStatus = useCallback((id, fieldName, status) => {
-    updateEntry(id, e => {
-      const fs = { ...e.field_statuses };
-      if (fieldName === 'totp') {
-        fs.totp = status;
-      } else if (fieldName === 'notes') {
-        fs.notes = status;
-      } else if (fieldName.startsWith('custom_field_')) {
-        const idx = parseInt(fieldName.split('_')[2], 10);
-        fs.custom_fields = [...fs.custom_fields];
-        fs.custom_fields[idx] = status;
-      } else if (fieldName.startsWith('attachment_')) {
-        const idx = parseInt(fieldName.split('_')[1], 10);
-        fs.attachments = [...fs.attachments];
-        fs.attachments[idx] = status;
-      }
-      return { ...e, field_statuses: fs };
+    setProgress(prev => {
+      const existing = prev.fieldStatuses[id] || {};
+      return {
+        ...prev,
+        fieldStatuses: {
+          ...prev.fieldStatuses,
+          [id]: { ...existing, [fieldName]: status },
+        },
+      };
     });
-  }, [updateEntry]);
+  }, [setProgress]);
+
+  const handleApplePasswordsCountChange = useCallback((count) => {
+    setProgress(prev => ({ ...prev, applePasswordsReported: count }));
+  }, [setProgress]);
 
   const backLink = (
     <a href="/tools/" className="text-sm text-blue-600 dark:text-blue-400 hover:underline mb-4 inline-block">
@@ -115,8 +127,8 @@ const App = () => {
         done={done}
         remaining={remaining}
         applePasswordsMarked={applePasswordsMarked}
-        applePasswordsReported={applePasswordsReported}
-        onApplePasswordsCountChange={setApplePasswordsReported}
+        applePasswordsReported={progress.applePasswordsReported}
+        onApplePasswordsCountChange={handleApplePasswordsCountChange}
         onReset={handleReset}
       />
 

--- a/src/pages/tools/password-migration/_app/components/EntryDetail.jsx
+++ b/src/pages/tools/password-migration/_app/components/EntryDetail.jsx
@@ -1,0 +1,252 @@
+import React, { useState } from 'react';
+
+function RevealField({ label, value }) {
+  const [revealed, setRevealed] = useState(false);
+
+  if (!value) return null;
+
+  return (
+    <div className="mb-3">
+      <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{label}</div>
+      {revealed ? (
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-sm text-gray-900 dark:text-gray-100 break-all">{value}</span>
+          <button
+            onClick={() => setRevealed(false)}
+            className="text-xs text-blue-600 dark:text-blue-400 hover:underline shrink-0"
+          >
+            Hide
+          </button>
+        </div>
+      ) : (
+        <button
+          title="Reveal"
+          onClick={() => setRevealed(true)}
+          className="flex items-center gap-2 text-left"
+        >
+          <span className="text-sm text-gray-400 dark:text-gray-500">Click to reveal</span>
+          <span className="text-xs text-blue-600 dark:text-blue-400 hover:underline shrink-0">
+            Reveal
+          </span>
+        </button>
+      )}
+    </div>
+  );
+}
+
+function PlainField({ label, value }) {
+  if (!value) return null;
+
+  return (
+    <div className="mb-3">
+      <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{label}</div>
+      <div className="text-sm text-gray-900 dark:text-gray-100 break-all">{value}</div>
+    </div>
+  );
+}
+
+function FieldStatusToggle({ value, onChange }) {
+  return (
+    <select
+      value={value || ''}
+      onChange={(e) => onChange(e.target.value || null)}
+      className="text-xs border border-gray-300 dark:border-gray-600 rounded px-1 py-0.5 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+    >
+      <option value="">Untracked</option>
+      <option value="migrated">Migrated</option>
+      <option value="discarded">Discarded</option>
+    </select>
+  );
+}
+
+const DISPOSITIONS = [
+  { key: 'apple_passwords', label: 'Apple Passwords' },
+  { key: 'uplock', label: 'Uplock' },
+  { key: 'apple_wallet', label: 'Apple Wallet' },
+  { key: 'deleted', label: 'Deleted' },
+];
+
+export function EntryDetail({
+  entry,
+  onSetDisposition,
+  onClearDisposition,
+  onUnpin,
+  onUpdateNotes,
+  onSetFieldStatus,
+}) {
+  const {
+    bitwarden_id, name, type, uris, username, password, totp, notes,
+    folder_name, custom_fields, attachments,
+    cardholder_name, card_brand, card_number, card_exp_month, card_exp_year, card_code,
+    identity_title, identity_first_name, identity_last_name,
+    identity_email, identity_phone, identity_address,
+    disposition, user_notes, field_statuses,
+  } = entry;
+
+  const hasCard = cardholder_name || card_brand || card_number || card_exp_month || card_code;
+  const hasIdentity = identity_title || identity_first_name || identity_last_name ||
+    identity_email || identity_phone || identity_address;
+
+  return (
+    <div className="p-4 space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-bold text-gray-900 dark:text-gray-100">{name}</h2>
+          <div className="flex items-center gap-2 mt-1">
+            <span className="text-xs px-2 py-0.5 rounded bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
+              {type}
+            </span>
+            {folder_name && (
+              <span className="text-xs text-gray-500 dark:text-gray-400">{folder_name}</span>
+            )}
+          </div>
+        </div>
+        <button
+          onClick={() => onUnpin(bitwarden_id)}
+          className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 text-xl leading-none"
+          title="Close"
+        >
+          &times;
+        </button>
+      </div>
+
+      {/* Login fields */}
+      {uris?.map((u, i) => (
+        <PlainField key={i} label={`URI ${i + 1}`} value={u.uri} />
+      ))}
+      <PlainField label="Username" value={username} />
+      <RevealField label="Password" value={password} />
+      <div className="flex items-center gap-2">
+        <div className="flex-1">
+          <RevealField label="TOTP" value={totp} />
+        </div>
+        {totp && (
+          <FieldStatusToggle
+            value={field_statuses?.totp}
+            onChange={(v) => onSetFieldStatus(bitwarden_id, 'totp', null, v)}
+          />
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        <div className="flex-1">
+          <PlainField label="Notes" value={notes} />
+        </div>
+        {notes && (
+          <FieldStatusToggle
+            value={field_statuses?.notes}
+            onChange={(v) => onSetFieldStatus(bitwarden_id, 'notes', null, v)}
+          />
+        )}
+      </div>
+
+      {/* Card fields */}
+      {hasCard && (
+        <div>
+          <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">Card</h3>
+          <PlainField label="Cardholder" value={cardholder_name} />
+          <PlainField label="Brand" value={card_brand} />
+          <RevealField label="Number" value={card_number} />
+          {(card_exp_month || card_exp_year) && (
+            <PlainField label="Expiry" value={`${card_exp_month || '??'}/${card_exp_year || '??'}`} />
+          )}
+          <RevealField label="CVV" value={card_code} />
+        </div>
+      )}
+
+      {/* Identity fields */}
+      {hasIdentity && (
+        <div>
+          <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">Identity</h3>
+          <PlainField label="Title" value={identity_title} />
+          <PlainField
+            label="Name"
+            value={[identity_first_name, identity_last_name].filter(Boolean).join(' ') || null}
+          />
+          <PlainField label="Email" value={identity_email} />
+          <PlainField label="Phone" value={identity_phone} />
+          <PlainField label="Address" value={identity_address} />
+        </div>
+      )}
+
+      {/* Custom fields */}
+      {custom_fields?.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">Custom Fields</h3>
+          {custom_fields.map((field, i) => (
+            <div key={i} className="flex items-center gap-2 mb-2">
+              <div className="flex-1">
+                {field.is_hidden ? (
+                  <RevealField label={field.name} value={field.value} />
+                ) : (
+                  <PlainField label={field.name} value={field.value} />
+                )}
+              </div>
+              <FieldStatusToggle
+                value={field_statuses?.custom_fields?.[i]}
+                onChange={(v) => onSetFieldStatus(bitwarden_id, 'custom_fields', i, v)}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Attachments */}
+      {attachments?.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">Attachments</h3>
+          {attachments.map((att, i) => (
+            <div key={i} className="flex items-center gap-2 mb-2">
+              <div className="flex-1">
+                {att.is_binary ? (
+                  <PlainField label={att.filename} value="(binary file)" />
+                ) : (
+                  <RevealField label={att.filename} value={att.content} />
+                )}
+              </div>
+              <FieldStatusToggle
+                value={field_statuses?.attachments?.[i]}
+                onChange={(v) => onSetFieldStatus(bitwarden_id, 'attachments', i, v)}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Disposition buttons */}
+      <div>
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">Disposition</h3>
+        <div className="flex flex-wrap gap-2">
+          {DISPOSITIONS.map(({ key, label }) => (
+            <button
+              key={key}
+              onClick={() =>
+                disposition === key
+                  ? onClearDisposition(bitwarden_id)
+                  : onSetDisposition(bitwarden_id, key)
+              }
+              className={`px-3 py-1.5 text-sm rounded-lg border transition-colors ${
+                disposition === key
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-blue-400'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* User notes */}
+      <div>
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">Your Notes</h3>
+        <textarea
+          value={user_notes || ''}
+          onChange={(e) => onUpdateNotes(bitwarden_id, e.target.value)}
+          placeholder="Add notes about this entry..."
+          className="w-full h-24 p-2 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 resize-y"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tools/password-migration/_app/components/EntryDetail.jsx
+++ b/src/pages/tools/password-migration/_app/components/EntryDetail.jsx
@@ -124,7 +124,7 @@ export function EntryDetail({
         {totp && (
           <FieldStatusToggle
             value={field_statuses?.totp}
-            onChange={(v) => onSetFieldStatus(bitwarden_id, 'totp', null, v)}
+            onChange={(v) => onSetFieldStatus(bitwarden_id, 'totp', v)}
           />
         )}
       </div>
@@ -135,7 +135,7 @@ export function EntryDetail({
         {notes && (
           <FieldStatusToggle
             value={field_statuses?.notes}
-            onChange={(v) => onSetFieldStatus(bitwarden_id, 'notes', null, v)}
+            onChange={(v) => onSetFieldStatus(bitwarden_id, 'notes', v)}
           />
         )}
       </div>
@@ -184,7 +184,7 @@ export function EntryDetail({
               </div>
               <FieldStatusToggle
                 value={field_statuses?.custom_fields?.[i]}
-                onChange={(v) => onSetFieldStatus(bitwarden_id, 'custom_fields', i, v)}
+                onChange={(v) => onSetFieldStatus(bitwarden_id, `custom_field_${i}`, v)}
               />
             </div>
           ))}
@@ -206,7 +206,7 @@ export function EntryDetail({
               </div>
               <FieldStatusToggle
                 value={field_statuses?.attachments?.[i]}
-                onChange={(v) => onSetFieldStatus(bitwarden_id, 'attachments', i, v)}
+                onChange={(v) => onSetFieldStatus(bitwarden_id, `attachment_${i}`, v)}
               />
             </div>
           ))}

--- a/src/pages/tools/password-migration/_app/components/EntryDetail.jsx
+++ b/src/pages/tools/password-migration/_app/components/EntryDetail.jsx
@@ -183,7 +183,7 @@ export function EntryDetail({
                 )}
               </div>
               <FieldStatusToggle
-                value={field_statuses?.custom_fields?.[i]}
+                value={field_statuses?.[`custom_field_${i}`]}
                 onChange={(v) => onSetFieldStatus(bitwarden_id, `custom_field_${i}`, v)}
               />
             </div>
@@ -205,7 +205,7 @@ export function EntryDetail({
                 )}
               </div>
               <FieldStatusToggle
-                value={field_statuses?.attachments?.[i]}
+                value={field_statuses?.[`attachment_${i}`]}
                 onChange={(v) => onSetFieldStatus(bitwarden_id, `attachment_${i}`, v)}
               />
             </div>

--- a/src/pages/tools/password-migration/_app/components/EntryDetail.jsx
+++ b/src/pages/tools/password-migration/_app/components/EntryDetail.jsx
@@ -130,7 +130,7 @@ export function EntryDetail({
       </div>
       <div className="flex items-center gap-2">
         <div className="flex-1">
-          <PlainField label="Notes" value={notes} />
+          <RevealField label="Notes" value={notes} />
         </div>
         {notes && (
           <FieldStatusToggle

--- a/src/pages/tools/password-migration/_app/components/EntryDetail.test.jsx
+++ b/src/pages/tools/password-migration/_app/components/EntryDetail.test.jsx
@@ -29,8 +29,8 @@ const makeEntry = (overrides) => ({
   field_statuses: {
     totp: null,
     notes: null,
-    custom_fields: [null],
-    attachments: [null],
+    custom_field_0: null,
+    attachment_0: null,
   },
   ...overrides,
 });

--- a/src/pages/tools/password-migration/_app/components/EntryDetail.test.jsx
+++ b/src/pages/tools/password-migration/_app/components/EntryDetail.test.jsx
@@ -81,4 +81,21 @@ describe('EntryDetail', () => {
     render(<EntryDetail entry={makeEntry()} {...handlers} />);
     expect(screen.getByText('API Key')).toBeInTheDocument();
   });
+
+  it('calls onSetFieldStatus with correct 3-arg format', () => {
+    const fns = { ...handlers, onSetFieldStatus: vi.fn() };
+    render(<EntryDetail entry={makeEntry()} {...fns} />);
+
+    // Change the TOTP field status dropdown
+    const selects = screen.getAllByRole('combobox');
+    // First select is TOTP, second is Notes, third is custom field, fourth is attachment
+    fireEvent.change(selects[0], { target: { value: 'migrated' } });
+    expect(fns.onSetFieldStatus).toHaveBeenCalledWith('id-1', 'totp', 'migrated');
+
+    fireEvent.change(selects[2], { target: { value: 'discarded' } });
+    expect(fns.onSetFieldStatus).toHaveBeenCalledWith('id-1', 'custom_field_0', 'discarded');
+
+    fireEvent.change(selects[3], { target: { value: 'migrated' } });
+    expect(fns.onSetFieldStatus).toHaveBeenCalledWith('id-1', 'attachment_0', 'migrated');
+  });
 });

--- a/src/pages/tools/password-migration/_app/components/EntryDetail.test.jsx
+++ b/src/pages/tools/password-migration/_app/components/EntryDetail.test.jsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { EntryDetail } from './EntryDetail.jsx';
+
+const makeEntry = (overrides) => ({
+  bitwarden_id: 'id-1',
+  name: 'GitHub',
+  type: 'login',
+  uris: [{ uri: 'https://github.com' }],
+  username: 'user@example.com',
+  password: 'secret',
+  totp: 'otpauth://totp/secret',
+  notes: 'Some notes',
+  folder_name: 'Dev',
+  custom_fields: [
+    { name: 'API Key', value: 'key-123', is_hidden: true },
+  ],
+  attachments: [
+    { filename: 'backup.txt', content: 'code1 code2', is_binary: false },
+  ],
+  cardholder_name: null, card_brand: null, card_number: null,
+  card_exp_month: null, card_exp_year: null, card_code: null,
+  identity_title: null, identity_first_name: null, identity_last_name: null,
+  identity_email: null, identity_phone: null, identity_address: null,
+  disposition: null,
+  user_notes: '',
+  is_pinned: true,
+  field_statuses: {
+    totp: null,
+    notes: null,
+    custom_fields: [null],
+    attachments: [null],
+  },
+  ...overrides,
+});
+
+describe('EntryDetail', () => {
+  afterEach(cleanup);
+
+  const handlers = {
+    onSetDisposition: vi.fn(),
+    onClearDisposition: vi.fn(),
+    onUnpin: vi.fn(),
+    onUpdateNotes: vi.fn(),
+    onSetFieldStatus: vi.fn(),
+  };
+
+  it('shows entry name and type', () => {
+    render(<EntryDetail entry={makeEntry()} {...handlers} />);
+    expect(screen.getByText('GitHub')).toBeInTheDocument();
+    expect(screen.getByText(/login/i)).toBeInTheDocument();
+  });
+
+  it('hides password behind reveal toggle', () => {
+    render(<EntryDetail entry={makeEntry()} {...handlers} />);
+    expect(screen.queryByText('secret')).not.toBeInTheDocument();
+    fireEvent.click(screen.getAllByText(/reveal/i)[0]);
+    expect(screen.getByText('secret')).toBeInTheDocument();
+  });
+
+  it('shows disposition buttons', () => {
+    render(<EntryDetail entry={makeEntry()} {...handlers} />);
+    expect(screen.getByRole('button', { name: /apple passwords/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /uplock/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /deleted/i })).toBeInTheDocument();
+  });
+
+  it('calls onSetDisposition when clicking a disposition', () => {
+    render(<EntryDetail entry={makeEntry()} {...handlers} />);
+    fireEvent.click(screen.getByRole('button', { name: /apple passwords/i }));
+    expect(handlers.onSetDisposition).toHaveBeenCalledWith('id-1', 'apple_passwords');
+  });
+
+  it('shows folder name', () => {
+    render(<EntryDetail entry={makeEntry()} {...handlers} />);
+    expect(screen.getByText('Dev')).toBeInTheDocument();
+  });
+
+  it('shows custom field names', () => {
+    render(<EntryDetail entry={makeEntry()} {...handlers} />);
+    expect(screen.getByText('API Key')).toBeInTheDocument();
+  });
+});

--- a/src/pages/tools/password-migration/_app/components/EntryList.jsx
+++ b/src/pages/tools/password-migration/_app/components/EntryList.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from 'react';
+import { EntryDetail } from './EntryDetail.jsx';
 
 const TYPE_LABELS = {
   login: 'Login',
@@ -19,38 +20,45 @@ function EntryRow({ entry, onPin }) {
   const isDone = entry.disposition != null;
 
   return (
-    <div
+    <tr
       onClick={() => onPin(entry.bitwarden_id)}
-      className={`flex items-center justify-between px-3 py-2 rounded cursor-pointer transition-colors ${
+      className={`cursor-pointer transition-colors ${
         entry.is_pinned
-          ? 'bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800'
+          ? 'bg-blue-50 dark:bg-blue-900/20'
           : isDone
             ? 'opacity-50 hover:opacity-70'
             : 'hover:bg-gray-100 dark:hover:bg-gray-700/50'
       }`}
     >
-      <div className="flex items-center gap-2 min-w-0">
-        <span className="text-xs px-1.5 py-0.5 rounded bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400 shrink-0">
+      <td className="py-1.5 px-2 text-xs w-14">
+        <span className="px-1.5 py-0.5 rounded bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400">
           {TYPE_LABELS[entry.type] || entry.type}
         </span>
-        <span className="text-gray-900 dark:text-gray-100 truncate">{entry.name}</span>
-        {entry.folder_name && (
-          <span className="text-xs text-gray-400 dark:text-gray-500 shrink-0">{entry.folder_name}</span>
+      </td>
+      <td className="py-1.5 px-2 text-sm text-gray-900 dark:text-gray-100 max-w-48 truncate">
+        {entry.name}{hasExtras && <span className="text-amber-500 ml-1" title="Has extra fields">*</span>}
+      </td>
+      <td className="py-1.5 px-2 text-xs text-gray-500 dark:text-gray-400 max-w-40 truncate">
+        {entry.username}
+      </td>
+      <td className="py-1.5 px-2 text-xs text-gray-400 dark:text-gray-500 max-w-48 truncate hidden sm:table-cell">
+        {entry.uris?.[0]?.uri?.replace(/^https?:\/\//, '')}
+      </td>
+      <td className="py-1.5 px-2 text-xs text-gray-400 dark:text-gray-500 max-w-24 truncate hidden md:table-cell">
+        {entry.folder_name}
+      </td>
+      <td className="py-1.5 px-2 text-xs text-right w-28">
+        {isDone && (
+          <span className="text-green-600 dark:text-green-400">
+            {DISPOSITION_LABELS[entry.disposition]}
+          </span>
         )}
-        {hasExtras && (
-          <span className="text-xs text-amber-500 shrink-0" title="Has extra fields">*</span>
-        )}
-      </div>
-      {isDone && (
-        <span className="text-xs text-green-600 dark:text-green-400 shrink-0 ml-2">
-          {DISPOSITION_LABELS[entry.disposition]}
-        </span>
-      )}
-    </div>
+      </td>
+    </tr>
   );
 }
 
-export function EntryList({ entries, onPin }) {
+export function EntryList({ entries, onPin, onSetDisposition, onClearDisposition, onUnpin, onUpdateNotes, onSetFieldStatus }) {
   const [search, setSearch] = useState('');
   const [typeFilter, setTypeFilter] = useState('');
 
@@ -60,6 +68,9 @@ export function EntryList({ entries, onPin }) {
       const q = search.toLowerCase();
       result = result.filter(e =>
         e.name.toLowerCase().includes(q) ||
+        e.folder_name?.toLowerCase().includes(q) ||
+        e.username?.toLowerCase().includes(q) ||
+        e.password?.toLowerCase().includes(q) ||
         e.uris?.some(u => u.uri.toLowerCase().includes(q))
       );
     }
@@ -69,9 +80,8 @@ export function EntryList({ entries, onPin }) {
     return result;
   }, [entries, search, typeFilter]);
 
-  const active = filtered.filter(e => e.disposition == null);
-  const done = filtered.filter(e => e.disposition != null);
-  active.sort((a, b) => (b.is_pinned ? 1 : 0) - (a.is_pinned ? 1 : 0));
+  const active = filtered.filter(e => e.disposition == null || e.is_pinned);
+  const done = filtered.filter(e => e.disposition != null && !e.is_pinned);
 
   return (
     <div>
@@ -88,21 +98,71 @@ export function EntryList({ entries, onPin }) {
           <option value="identity">Identity</option>
         </select>
       </div>
-      <div className="space-y-1">
-        {active.map(entry => (
-          <EntryRow key={entry.bitwarden_id} entry={entry} onPin={onPin} />
-        ))}
-      </div>
+      <table className="w-full border-collapse">
+        <thead>
+          <tr className="text-xs text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+            <th className="py-1.5 px-2 text-left font-medium w-14">Type</th>
+            <th className="py-1.5 px-2 text-left font-medium max-w-48">Name</th>
+            <th className="py-1.5 px-2 text-left font-medium max-w-40">Username</th>
+            <th className="py-1.5 px-2 text-left font-medium max-w-48 hidden sm:table-cell">URL</th>
+            <th className="py-1.5 px-2 text-left font-medium max-w-24 hidden md:table-cell">Folder</th>
+            <th className="py-1.5 px-2 text-right font-medium w-28">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {active.map(entry => (
+            <React.Fragment key={entry.bitwarden_id}>
+              <EntryRow entry={entry} onPin={onPin} />
+              {entry.is_pinned && (
+                <tr>
+                  <td colSpan="6" className="p-0">
+                    <div className="border border-blue-200 dark:border-blue-800 rounded-b-lg mb-2">
+                      <EntryDetail
+                        entry={entry}
+                        onSetDisposition={onSetDisposition}
+                        onClearDisposition={onClearDisposition}
+                        onUnpin={onUnpin}
+                        onUpdateNotes={onUpdateNotes}
+                        onSetFieldStatus={onSetFieldStatus}
+                      />
+                    </div>
+                  </td>
+                </tr>
+              )}
+            </React.Fragment>
+          ))}
+        </tbody>
+      </table>
       {done.length > 0 && (
         <>
           <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400 mt-6 mb-2">
             Done ({done.length})
           </h3>
-          <div className="space-y-1">
-            {done.map(entry => (
-              <EntryRow key={entry.bitwarden_id} entry={entry} onPin={onPin} />
-            ))}
-          </div>
+          <table className="w-full border-collapse">
+            <tbody>
+              {done.map(entry => (
+                <React.Fragment key={entry.bitwarden_id}>
+                  <EntryRow entry={entry} onPin={onPin} />
+                  {entry.is_pinned && (
+                    <tr>
+                      <td colSpan="6" className="p-0">
+                        <div className="border border-blue-200 dark:border-blue-800 rounded-b-lg mb-2">
+                          <EntryDetail
+                            entry={entry}
+                            onSetDisposition={onSetDisposition}
+                            onClearDisposition={onClearDisposition}
+                            onUnpin={onUnpin}
+                            onUpdateNotes={onUpdateNotes}
+                            onSetFieldStatus={onSetFieldStatus}
+                          />
+                        </div>
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
+              ))}
+            </tbody>
+          </table>
         </>
       )}
     </div>

--- a/src/pages/tools/password-migration/_app/components/EntryList.jsx
+++ b/src/pages/tools/password-migration/_app/components/EntryList.jsx
@@ -1,0 +1,110 @@
+import React, { useState, useMemo } from 'react';
+
+const TYPE_LABELS = {
+  login: 'Login',
+  secure_note: 'Note',
+  card: 'Card',
+  identity: 'Identity',
+};
+
+const DISPOSITION_LABELS = {
+  apple_passwords: 'Apple Passwords',
+  uplock: 'Uplock',
+  apple_wallet: 'Apple Wallet',
+  deleted: 'Deleted',
+};
+
+function EntryRow({ entry, onPin }) {
+  const hasExtras = entry.custom_fields.length > 0 || entry.totp || entry.attachments.length > 0;
+  const isDone = entry.disposition != null;
+
+  return (
+    <div
+      onClick={() => onPin(entry.bitwarden_id)}
+      className={`flex items-center justify-between px-3 py-2 rounded cursor-pointer transition-colors ${
+        entry.is_pinned
+          ? 'bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800'
+          : isDone
+            ? 'opacity-50 hover:opacity-70'
+            : 'hover:bg-gray-100 dark:hover:bg-gray-700/50'
+      }`}
+    >
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="text-xs px-1.5 py-0.5 rounded bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400 shrink-0">
+          {TYPE_LABELS[entry.type] || entry.type}
+        </span>
+        <span className="text-gray-900 dark:text-gray-100 truncate">{entry.name}</span>
+        {entry.folder_name && (
+          <span className="text-xs text-gray-400 dark:text-gray-500 shrink-0">{entry.folder_name}</span>
+        )}
+        {hasExtras && (
+          <span className="text-xs text-amber-500 shrink-0" title="Has extra fields">*</span>
+        )}
+      </div>
+      {isDone && (
+        <span className="text-xs text-green-600 dark:text-green-400 shrink-0 ml-2">
+          {DISPOSITION_LABELS[entry.disposition]}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function EntryList({ entries, onPin }) {
+  const [search, setSearch] = useState('');
+  const [typeFilter, setTypeFilter] = useState('');
+
+  const filtered = useMemo(() => {
+    let result = entries;
+    if (search) {
+      const q = search.toLowerCase();
+      result = result.filter(e =>
+        e.name.toLowerCase().includes(q) ||
+        e.uris?.some(u => u.uri.toLowerCase().includes(q))
+      );
+    }
+    if (typeFilter) {
+      result = result.filter(e => e.type === typeFilter);
+    }
+    return result;
+  }, [entries, search, typeFilter]);
+
+  const active = filtered.filter(e => e.disposition == null);
+  const done = filtered.filter(e => e.disposition != null);
+  active.sort((a, b) => (b.is_pinned ? 1 : 0) - (a.is_pinned ? 1 : 0));
+
+  return (
+    <div>
+      <div className="flex gap-2 mb-3">
+        <input type="text" placeholder="Search entries..."
+          value={search} onChange={e => setSearch(e.target.value)}
+          className="flex-1 px-3 py-2 border rounded dark:bg-gray-800 dark:border-gray-600 text-sm" />
+        <select value={typeFilter} onChange={e => setTypeFilter(e.target.value)}
+          className="px-3 py-2 border rounded dark:bg-gray-800 dark:border-gray-600 text-sm">
+          <option value="">All types</option>
+          <option value="login">Login</option>
+          <option value="secure_note">Note</option>
+          <option value="card">Card</option>
+          <option value="identity">Identity</option>
+        </select>
+      </div>
+      <div className="space-y-1">
+        {active.map(entry => (
+          <EntryRow key={entry.bitwarden_id} entry={entry} onPin={onPin} />
+        ))}
+      </div>
+      {done.length > 0 && (
+        <>
+          <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400 mt-6 mb-2">
+            Done ({done.length})
+          </h3>
+          <div className="space-y-1">
+            {done.map(entry => (
+              <EntryRow key={entry.bitwarden_id} entry={entry} onPin={onPin} />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/pages/tools/password-migration/_app/components/EntryList.test.jsx
+++ b/src/pages/tools/password-migration/_app/components/EntryList.test.jsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { EntryList } from './EntryList.jsx';
+
+const makeEntry = (overrides) => ({
+  bitwarden_id: 'id-1',
+  name: 'GitHub',
+  type: 'login',
+  uris: [{ uri: 'https://github.com' }],
+  disposition: null,
+  is_pinned: false,
+  folder_name: 'Dev',
+  custom_fields: [],
+  attachments: [],
+  totp: null,
+  ...overrides,
+});
+
+describe('EntryList', () => {
+  afterEach(() => cleanup());
+  it('renders active entries', () => {
+    const entries = [makeEntry()];
+    render(<EntryList entries={entries} onPin={vi.fn()} />);
+    expect(screen.getByText('GitHub')).toBeInTheDocument();
+    expect(screen.getByText('Dev')).toBeInTheDocument();
+  });
+
+  it('separates done entries', () => {
+    const entries = [
+      makeEntry({ bitwarden_id: '1', name: 'Active', disposition: null }),
+      makeEntry({ bitwarden_id: '2', name: 'Done', disposition: 'apple_passwords' }),
+    ];
+    render(<EntryList entries={entries} onPin={vi.fn()} />);
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText('Done')).toBeInTheDocument();
+  });
+
+  it('filters by search text', () => {
+    const entries = [
+      makeEntry({ bitwarden_id: '1', name: 'GitHub' }),
+      makeEntry({ bitwarden_id: '2', name: 'Gmail', uris: [{ uri: 'https://mail.google.com' }] }),
+    ];
+    render(<EntryList entries={entries} onPin={vi.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: 'git' } });
+    expect(screen.getByText('GitHub')).toBeInTheDocument();
+    expect(screen.queryByText('Gmail')).not.toBeInTheDocument();
+  });
+
+  it('filters by type', () => {
+    const entries = [
+      makeEntry({ bitwarden_id: '1', name: 'Login Item', type: 'login' }),
+      makeEntry({ bitwarden_id: '2', name: 'Note Item', type: 'secure_note' }),
+    ];
+    render(<EntryList entries={entries} onPin={vi.fn()} />);
+    fireEvent.change(screen.getByDisplayValue('All types'), { target: { value: 'secure_note' } });
+    expect(screen.queryByText('Login Item')).not.toBeInTheDocument();
+    expect(screen.getByText('Note Item')).toBeInTheDocument();
+  });
+
+  it('calls onPin when clicking an entry', () => {
+    const onPin = vi.fn();
+    render(<EntryList entries={[makeEntry()]} onPin={onPin} />);
+    fireEvent.click(screen.getByText('GitHub'));
+    expect(onPin).toHaveBeenCalledWith('id-1');
+  });
+});

--- a/src/pages/tools/password-migration/_app/components/ProgressDashboard.jsx
+++ b/src/pages/tools/password-migration/_app/components/ProgressDashboard.jsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+
+export function ProgressDashboard({
+  total, done, remaining,
+  applePasswordsMarked, applePasswordsReported,
+  onApplePasswordsCountChange, onReset,
+}) {
+  const [showConfirm, setShowConfirm] = useState(false);
+  const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+  const delta = applePasswordsReported != null
+    ? applePasswordsReported - applePasswordsMarked
+    : null;
+
+  return (
+    <div className="mb-6 p-4 bg-white dark:bg-gray-800 rounded-lg shadow-sm">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Progress</h2>
+        {showConfirm ? (
+          <div className="flex gap-2">
+            <span className="text-sm text-gray-600 dark:text-gray-400">Reset all data?</span>
+            <button onClick={() => { onReset(); setShowConfirm(false); }}
+              className="text-sm px-2 py-1 bg-red-600 text-white rounded">Confirm</button>
+            <button onClick={() => setShowConfirm(false)}
+              className="text-sm px-2 py-1 bg-gray-300 dark:bg-gray-600 rounded">Cancel</button>
+          </div>
+        ) : (
+          <button onClick={() => setShowConfirm(true)}
+            className="text-sm text-red-600 dark:text-red-400 hover:underline">Reset</button>
+        )}
+      </div>
+      <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-3 mb-2">
+        <div className="bg-green-500 h-3 rounded-full transition-all" style={{ width: `${pct}%` }} />
+      </div>
+      <div className="flex gap-6 text-sm text-gray-600 dark:text-gray-400 mb-3">
+        <span><strong className="text-gray-900 dark:text-gray-100">{done}</strong> done</span>
+        <span><strong className="text-gray-900 dark:text-gray-100">{remaining}</strong> remaining</span>
+        <span><strong className="text-gray-900 dark:text-gray-100">{total}</strong> total</span>
+      </div>
+      <div className="flex items-center gap-3 text-sm">
+        <label className="text-gray-600 dark:text-gray-400">
+          Apple Passwords count:
+          <input type="number"
+            value={applePasswordsReported ?? ''}
+            onChange={e => onApplePasswordsCountChange(e.target.value === '' ? null : parseInt(e.target.value, 10))}
+            className="ml-2 w-20 px-2 py-1 border rounded dark:bg-gray-700 dark:border-gray-600"
+            placeholder="..." />
+        </label>
+        <span className="text-gray-500 dark:text-gray-500">Marked: {applePasswordsMarked}</span>
+        {delta != null && (
+          <span className={delta === 0 ? 'text-green-600' : 'text-amber-600'}>
+            Delta: {delta > 0 ? '+' : ''}{delta}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tools/password-migration/_app/components/ProgressDashboard.test.jsx
+++ b/src/pages/tools/password-migration/_app/components/ProgressDashboard.test.jsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ProgressDashboard } from './ProgressDashboard.jsx';
+
+afterEach(cleanup);
+
+describe('ProgressDashboard', () => {
+  const defaults = {
+    total: 580,
+    done: 200,
+    remaining: 380,
+    applePasswordsMarked: 150,
+    applePasswordsReported: null,
+    onApplePasswordsCountChange: vi.fn(),
+    onReset: vi.fn(),
+  };
+
+  it('shows progress counts', () => {
+    render(<ProgressDashboard {...defaults} />);
+    expect(screen.getByText(/200/)).toBeInTheDocument();
+    expect(screen.getByText(/580/)).toBeInTheDocument();
+    expect(screen.getByText(/380/)).toBeInTheDocument();
+  });
+
+  it('shows checksum delta when reported count entered', () => {
+    render(<ProgressDashboard {...defaults} applePasswordsReported={160} />);
+    expect(screen.getByText(/10/)).toBeInTheDocument();
+  });
+
+  it('has a reset button', () => {
+    render(<ProgressDashboard {...defaults} />);
+    expect(screen.getByRole('button', { name: /reset/i })).toBeInTheDocument();
+  });
+});

--- a/src/pages/tools/password-migration/_app/components/UploadView.jsx
+++ b/src/pages/tools/password-migration/_app/components/UploadView.jsx
@@ -1,0 +1,40 @@
+import React, { useCallback } from 'react';
+
+export function UploadView({ onImport, isLoading, error }) {
+  const handleFile = useCallback((e) => {
+    const file = e.target.files?.[0];
+    if (file) onImport(file);
+  }, [onImport]);
+
+  return (
+    <div className="max-w-xl mx-auto p-8 text-center">
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+        Password Migration Helper
+      </h1>
+      <p className="text-gray-600 dark:text-gray-400 mb-8">
+        Upload your Bitwarden .zip export to begin tracking your migration
+        to Apple Passwords and Uplock.
+      </p>
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded">
+          {error}
+        </div>
+      )}
+
+      {isLoading ? (
+        <p className="text-gray-500 dark:text-gray-400">Parsing export...</p>
+      ) : (
+        <label className="inline-block cursor-pointer px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+          Choose .zip file
+          <input
+            type="file"
+            accept=".zip"
+            onChange={handleFile}
+            className="hidden"
+          />
+        </label>
+      )}
+    </div>
+  );
+}

--- a/src/pages/tools/password-migration/_app/components/UploadView.test.jsx
+++ b/src/pages/tools/password-migration/_app/components/UploadView.test.jsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { UploadView } from './UploadView.jsx';
+
+describe('UploadView', () => {
+  it('renders upload prompt', () => {
+    render(<UploadView onImport={vi.fn()} isLoading={false} error={null} />);
+    expect(screen.getByText(/upload.*bitwarden/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/\.zip/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows loading state', () => {
+    render(<UploadView onImport={vi.fn()} isLoading={true} error={null} />);
+    expect(screen.getByText(/parsing/i)).toBeInTheDocument();
+  });
+
+  it('shows error message', () => {
+    render(<UploadView onImport={vi.fn()} isLoading={false} error="Bad zip" />);
+    expect(screen.getByText('Bad zip')).toBeInTheDocument();
+  });
+});

--- a/src/pages/tools/password-migration/_app/hooks.js
+++ b/src/pages/tools/password-migration/_app/hooks.js
@@ -1,30 +1,70 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 
-const STORAGE_PREFIX = 'passwordMigration_';
+const VAULT_KEY = 'passwordMigration_vault';
+const PROGRESS_KEY = 'passwordMigration_progress';
 
-export function useLocalStorage(key, initialValue) {
-  const fullKey = STORAGE_PREFIX + key;
-  const [value, setValue] = useState(() => {
+const EMPTY_PROGRESS = {
+  dispositions: {},
+  fieldStatuses: {},
+  userNotes: {},
+  pinnedId: null,
+  applePasswordsReported: null,
+};
+
+// Vault: sessionStorage (sensitive, dies with tab)
+
+export function useVault() {
+  const [vault, setVaultState] = useState(() => {
     try {
-      const stored = localStorage.getItem(fullKey);
-      return stored !== null ? JSON.parse(stored) : initialValue;
+      const stored = sessionStorage.getItem(VAULT_KEY);
+      return stored ? JSON.parse(stored) : null;
     } catch {
-      return initialValue;
+      return null;
     }
   });
 
-  useEffect(() => {
-    localStorage.setItem(fullKey, JSON.stringify(value));
-  }, [fullKey, value]);
+  const setVault = useCallback((entries) => {
+    setVaultState(entries);
+    if (entries) {
+      sessionStorage.setItem(VAULT_KEY, JSON.stringify(entries));
+    } else {
+      sessionStorage.removeItem(VAULT_KEY);
+    }
+  }, []);
 
-  return [value, setValue];
+  return [vault, setVault];
 }
 
-export function clearAllStorage() {
-  const keys = [];
-  for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i);
-    if (key.startsWith(STORAGE_PREFIX)) keys.push(key);
-  }
-  keys.forEach(k => localStorage.removeItem(k));
+// Progress: localStorage (non-sensitive, persists across sessions)
+
+export function useProgress() {
+  const [progress, setProgressState] = useState(() => {
+    try {
+      const stored = localStorage.getItem(PROGRESS_KEY);
+      return stored ? { ...EMPTY_PROGRESS, ...JSON.parse(stored) } : EMPTY_PROGRESS;
+    } catch {
+      return EMPTY_PROGRESS;
+    }
+  });
+
+  const setProgress = useCallback((updater) => {
+    setProgressState(prev => {
+      const next = typeof updater === 'function' ? updater(prev) : updater;
+      try {
+        localStorage.setItem(PROGRESS_KEY, JSON.stringify(next));
+      } catch {
+        // quota exceeded — progress not saved, but app still works
+      }
+      return next;
+    });
+  }, []);
+
+  return [progress, setProgress];
+}
+
+// Clear everything
+
+export function clearAll() {
+  sessionStorage.removeItem(VAULT_KEY);
+  localStorage.removeItem(PROGRESS_KEY);
 }

--- a/src/pages/tools/password-migration/_app/hooks.js
+++ b/src/pages/tools/password-migration/_app/hooks.js
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react';
+
+const STORAGE_PREFIX = 'passwordMigration_';
+
+export function useLocalStorage(key, initialValue) {
+  const fullKey = STORAGE_PREFIX + key;
+  const [value, setValue] = useState(() => {
+    try {
+      const stored = localStorage.getItem(fullKey);
+      return stored !== null ? JSON.parse(stored) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    localStorage.setItem(fullKey, JSON.stringify(value));
+  }, [fullKey, value]);
+
+  return [value, setValue];
+}
+
+export function clearAllStorage() {
+  const keys = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key.startsWith(STORAGE_PREFIX)) keys.push(key);
+  }
+  keys.forEach(k => localStorage.removeItem(k));
+}

--- a/src/pages/tools/password-migration/_app/hooks.js
+++ b/src/pages/tools/password-migration/_app/hooks.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 const VAULT_KEY = 'passwordMigration_vault';
 const PROGRESS_KEY = 'passwordMigration_progress';
@@ -29,7 +29,11 @@ export function useVault() {
   const setVault = useCallback((entries) => {
     setVaultState(entries);
     if (entries) {
-      sessionStorage.setItem(VAULT_KEY, JSON.stringify(entries));
+      try {
+        sessionStorage.setItem(VAULT_KEY, JSON.stringify(entries));
+      } catch {
+        // Quota exceeded — vault lives in memory only, won't survive refresh
+      }
     } else {
       sessionStorage.removeItem(VAULT_KEY);
     }
@@ -50,14 +54,19 @@ export function useProgress() {
     }
   });
 
+  const saveTimer = useRef(null);
+
   const setProgress = useCallback((updater) => {
     setProgressState(prev => {
       const next = typeof updater === 'function' ? updater(prev) : updater;
-      try {
-        localStorage.setItem(PROGRESS_KEY, JSON.stringify(next));
-      } catch {
-        // quota exceeded — progress not saved, but app still works
-      }
+      clearTimeout(saveTimer.current);
+      saveTimer.current = setTimeout(() => {
+        try {
+          localStorage.setItem(PROGRESS_KEY, JSON.stringify(next));
+        } catch {
+          // quota exceeded — progress not saved, but app still works
+        }
+      }, 300);
       return next;
     });
   }, []);

--- a/src/pages/tools/password-migration/_app/hooks.js
+++ b/src/pages/tools/password-migration/_app/hooks.js
@@ -4,6 +4,9 @@ const VAULT_KEY = 'passwordMigration_vault';
 const PROGRESS_KEY = 'passwordMigration_progress';
 
 const EMPTY_PROGRESS = {
+  // Non-sensitive entry metadata for rendering without vault
+  // { [bitwarden_id]: { name, type, folder_name } }
+  manifest: {},
   dispositions: {},
   fieldStatuses: {},
   userNotes: {},

--- a/src/pages/tools/password-migration/_app/hooks.test.js
+++ b/src/pages/tools/password-migration/_app/hooks.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLocalStorage } from './hooks.js';
+
+beforeEach(() => localStorage.clear());
+
+describe('useLocalStorage', () => {
+  it('returns initial value when nothing stored', () => {
+    const { result } = renderHook(() => useLocalStorage('key', 'default'));
+    expect(result.current[0]).toBe('default');
+  });
+
+  it('persists value to localStorage', () => {
+    const { result } = renderHook(() => useLocalStorage('key', 'default'));
+    act(() => result.current[1]('updated'));
+    expect(result.current[0]).toBe('updated');
+    expect(JSON.parse(localStorage.getItem('passwordMigration_key'))).toBe('updated');
+  });
+
+  it('reads existing value from localStorage', () => {
+    localStorage.setItem('passwordMigration_key', JSON.stringify('stored'));
+    const { result } = renderHook(() => useLocalStorage('key', 'default'));
+    expect(result.current[0]).toBe('stored');
+  });
+});

--- a/src/pages/tools/password-migration/_app/hooks.test.js
+++ b/src/pages/tools/password-migration/_app/hooks.test.js
@@ -1,25 +1,56 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useLocalStorage } from './hooks.js';
+import { useVault, useProgress, clearAll } from './hooks.js';
 
-beforeEach(() => localStorage.clear());
+beforeEach(() => {
+  sessionStorage.clear();
+  localStorage.clear();
+});
 
-describe('useLocalStorage', () => {
-  it('returns initial value when nothing stored', () => {
-    const { result } = renderHook(() => useLocalStorage('key', 'default'));
-    expect(result.current[0]).toBe('default');
+describe('useVault', () => {
+  it('returns null when nothing stored', () => {
+    const { result } = renderHook(() => useVault());
+    expect(result.current[0]).toBeNull();
   });
 
-  it('persists value to localStorage', () => {
-    const { result } = renderHook(() => useLocalStorage('key', 'default'));
-    act(() => result.current[1]('updated'));
-    expect(result.current[0]).toBe('updated');
-    expect(JSON.parse(localStorage.getItem('passwordMigration_key'))).toBe('updated');
+  it('stores vault in sessionStorage', () => {
+    const { result } = renderHook(() => useVault());
+    act(() => result.current[1]([{ id: '1' }]));
+    expect(result.current[0]).toEqual([{ id: '1' }]);
+    expect(JSON.parse(sessionStorage.getItem('passwordMigration_vault'))).toEqual([{ id: '1' }]);
+    expect(localStorage.getItem('passwordMigration_vault')).toBeNull();
   });
 
-  it('reads existing value from localStorage', () => {
-    localStorage.setItem('passwordMigration_key', JSON.stringify('stored'));
-    const { result } = renderHook(() => useLocalStorage('key', 'default'));
-    expect(result.current[0]).toBe('stored');
+  it('reads existing vault from sessionStorage', () => {
+    sessionStorage.setItem('passwordMigration_vault', JSON.stringify([{ id: '2' }]));
+    const { result } = renderHook(() => useVault());
+    expect(result.current[0]).toEqual([{ id: '2' }]);
+  });
+});
+
+describe('useProgress', () => {
+  it('returns empty progress when nothing stored', () => {
+    const { result } = renderHook(() => useProgress());
+    expect(result.current[0].dispositions).toEqual({});
+    expect(result.current[0].pinnedId).toBeNull();
+  });
+
+  it('stores progress in localStorage', () => {
+    const { result } = renderHook(() => useProgress());
+    act(() => result.current[1](prev => ({ ...prev, pinnedId: 'abc' })));
+    expect(result.current[0].pinnedId).toBe('abc');
+    const stored = JSON.parse(localStorage.getItem('passwordMigration_progress'));
+    expect(stored.pinnedId).toBe('abc');
+    expect(sessionStorage.getItem('passwordMigration_progress')).toBeNull();
+  });
+});
+
+describe('clearAll', () => {
+  it('removes both vault and progress', () => {
+    sessionStorage.setItem('passwordMigration_vault', 'data');
+    localStorage.setItem('passwordMigration_progress', 'data');
+    clearAll();
+    expect(sessionStorage.getItem('passwordMigration_vault')).toBeNull();
+    expect(localStorage.getItem('passwordMigration_progress')).toBeNull();
   });
 });

--- a/src/pages/tools/password-migration/_app/hooks.test.js
+++ b/src/pages/tools/password-migration/_app/hooks.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useVault, useProgress, clearAll } from './hooks.js';
 
@@ -35,13 +35,18 @@ describe('useProgress', () => {
     expect(result.current[0].pinnedId).toBeNull();
   });
 
-  it('stores progress in localStorage', () => {
+  it('stores progress in localStorage (debounced)', () => {
+    vi.useFakeTimers();
     const { result } = renderHook(() => useProgress());
     act(() => result.current[1](prev => ({ ...prev, pinnedId: 'abc' })));
     expect(result.current[0].pinnedId).toBe('abc');
+    // Not saved yet (debounced)
+    expect(localStorage.getItem('passwordMigration_progress')).toBeNull();
+    act(() => { vi.advanceTimersByTime(300); });
     const stored = JSON.parse(localStorage.getItem('passwordMigration_progress'));
     expect(stored.pinnedId).toBe('abc');
     expect(sessionStorage.getItem('passwordMigration_progress')).toBeNull();
+    vi.useRealTimers();
   });
 });
 

--- a/src/pages/tools/password-migration/_app/parser.js
+++ b/src/pages/tools/password-migration/_app/parser.js
@@ -1,0 +1,122 @@
+const TYPE_MAP = { 1: 'login', 2: 'secure_note', 3: 'card', 4: 'identity' };
+const FIELD_TYPE_HIDDEN = 1;
+
+export function mapFolders(folders) {
+  const map = {};
+  for (const f of folders) {
+    map[f.id] = f.name;
+  }
+  return map;
+}
+
+export function parseBitwardenItem(item, folderMap) {
+  const base = {
+    bitwarden_id: item.id,
+    name: item.name,
+    type: TYPE_MAP[item.type] || 'unknown',
+    notes: item.notes || null,
+    is_favorite: item.favorite || false,
+    folder_name: item.folderId ? (folderMap[item.folderId] || null) : null,
+    custom_fields: (item.fields || []).map(f => ({
+      name: f.name,
+      value: f.value,
+      is_hidden: f.type === FIELD_TYPE_HIDDEN,
+    })),
+    attachments: [],
+    disposition: null,
+    user_notes: '',
+    is_pinned: false,
+    field_statuses: {
+      totp: null,
+      notes: null,
+      custom_fields: [],
+      attachments: [],
+    },
+  };
+
+  base.uris = [];
+  base.username = null;
+  base.password = null;
+  base.totp = null;
+  if (item.type === 1 && item.login) {
+    base.uris = (item.login.uris || []).map(u => ({ uri: u.uri }));
+    base.username = item.login.username || null;
+    base.password = item.login.password || null;
+    base.totp = item.login.totp || null;
+  }
+
+  base.cardholder_name = null;
+  base.card_brand = null;
+  base.card_number = null;
+  base.card_exp_month = null;
+  base.card_exp_year = null;
+  base.card_code = null;
+  if (item.type === 3 && item.card) {
+    base.cardholder_name = item.card.cardholderName || null;
+    base.card_brand = item.card.brand || null;
+    base.card_number = item.card.number || null;
+    base.card_exp_month = item.card.expMonth || null;
+    base.card_exp_year = item.card.expYear || null;
+    base.card_code = item.card.code || null;
+  }
+
+  base.identity_title = null;
+  base.identity_first_name = null;
+  base.identity_last_name = null;
+  base.identity_email = null;
+  base.identity_phone = null;
+  base.identity_address = null;
+  if (item.type === 4 && item.identity) {
+    const id = item.identity;
+    base.identity_title = id.title || null;
+    base.identity_first_name = id.firstName || null;
+    base.identity_last_name = id.lastName || null;
+    base.identity_email = id.email || null;
+    base.identity_phone = id.phone || null;
+    base.identity_address = [id.address1, id.address2, id.address3, id.city, id.state, id.postalCode, id.country]
+      .filter(Boolean)
+      .join(', ') || null;
+  }
+
+  base.field_statuses.custom_fields = base.custom_fields.map(() => null);
+
+  return base;
+}
+
+export async function parseZipExport(zipFile) {
+  const JSZip = (await import('jszip')).default;
+  const zip = await JSZip.loadAsync(zipFile);
+
+  const dataFile = zip.file('data.json');
+  if (!dataFile) throw new Error('No data.json found in zip');
+
+  const dataJson = await dataFile.async('string');
+  const data = JSON.parse(dataJson);
+
+  const folderMap = mapFolders(data.folders || []);
+  const entries = (data.items || []).map(item => parseBitwardenItem(item, folderMap));
+
+  for (const entry of entries) {
+    const itemAttachments = (data.items.find(i => i.id === entry.bitwarden_id)?.attachments) || [];
+    for (const att of itemAttachments) {
+      const attFile = zip.file(att.fileName);
+      let content = null;
+      let is_binary = false;
+      if (attFile) {
+        try {
+          content = await attFile.async('string');
+          if (/[\x00-\x08\x0E-\x1F]/.test(content.substring(0, 1000))) {
+            content = null;
+            is_binary = true;
+          }
+        } catch {
+          is_binary = true;
+        }
+      }
+      entry.attachments.push({ filename: att.fileName, content, is_binary });
+    }
+    entry.field_statuses.attachments = entry.attachments.map(() => null);
+  }
+
+  return entries;
+}

--- a/src/pages/tools/password-migration/_app/parser.test.js
+++ b/src/pages/tools/password-migration/_app/parser.test.js
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { parseBitwardenItem, mapFolders } from './parser.js';
+
+describe('mapFolders', () => {
+  it('maps folder IDs to names', () => {
+    const folders = [
+      { id: 'f1', name: 'Social' },
+      { id: 'f2', name: 'Work' },
+    ];
+    expect(mapFolders(folders)).toEqual({ f1: 'Social', f2: 'Work' });
+  });
+
+  it('returns empty map for empty array', () => {
+    expect(mapFolders([])).toEqual({});
+  });
+});
+
+describe('parseBitwardenItem', () => {
+  const folderMap = { 'folder-1': 'Social Media' };
+
+  it('parses a login item', () => {
+    const item = {
+      id: 'abc-123',
+      type: 1,
+      name: 'GitHub',
+      notes: 'my notes',
+      favorite: true,
+      folderId: 'folder-1',
+      login: {
+        uris: [{ uri: 'https://github.com', match: null }],
+        username: 'user@example.com',
+        password: 'secret123',
+        totp: 'otpauth://totp/GitHub?secret=ABC',
+      },
+      fields: [
+        { name: 'API Key', value: 'key-123', type: 1 },
+        { name: 'Recovery', value: 'code1 code2', type: 0 },
+      ],
+    };
+
+    const result = parseBitwardenItem(item, folderMap);
+
+    expect(result.bitwarden_id).toBe('abc-123');
+    expect(result.name).toBe('GitHub');
+    expect(result.type).toBe('login');
+    expect(result.folder_name).toBe('Social Media');
+    expect(result.notes).toBe('my notes');
+    expect(result.is_favorite).toBe(true);
+    expect(result.uris).toEqual([{ uri: 'https://github.com' }]);
+    expect(result.username).toBe('user@example.com');
+    expect(result.password).toBe('secret123');
+    expect(result.totp).toBe('otpauth://totp/GitHub?secret=ABC');
+    expect(result.custom_fields).toEqual([
+      { name: 'API Key', value: 'key-123', is_hidden: true },
+      { name: 'Recovery', value: 'code1 code2', is_hidden: false },
+    ]);
+  });
+
+  it('parses a secure note', () => {
+    const item = {
+      id: 'note-1',
+      type: 2,
+      name: 'Server Info',
+      notes: 'SSH details here',
+      favorite: false,
+      folderId: null,
+      secureNote: {},
+      fields: null,
+    };
+
+    const result = parseBitwardenItem(item, folderMap);
+
+    expect(result.type).toBe('secure_note');
+    expect(result.folder_name).toBeNull();
+    expect(result.custom_fields).toEqual([]);
+  });
+
+  it('parses a card item', () => {
+    const item = {
+      id: 'card-1',
+      type: 3,
+      name: 'Visa',
+      notes: null,
+      favorite: false,
+      folderId: null,
+      card: {
+        cardholderName: 'Oliver',
+        brand: 'Visa',
+        number: '4111111111111111',
+        expMonth: '12',
+        expYear: '2028',
+        code: '123',
+      },
+      fields: null,
+    };
+
+    const result = parseBitwardenItem(item, folderMap);
+
+    expect(result.type).toBe('card');
+    expect(result.card_number).toBe('4111111111111111');
+    expect(result.card_brand).toBe('Visa');
+    expect(result.card_exp_month).toBe('12');
+    expect(result.card_code).toBe('123');
+  });
+
+  it('parses an identity item', () => {
+    const item = {
+      id: 'id-1',
+      type: 4,
+      name: 'Personal',
+      notes: null,
+      favorite: false,
+      folderId: null,
+      identity: {
+        title: 'Mr',
+        firstName: 'Oliver',
+        middleName: null,
+        lastName: 'Smith',
+        email: 'oliver@example.com',
+        phone: '+441234567890',
+        address1: '123 Main St',
+        address2: null,
+        address3: null,
+        city: 'London',
+        state: null,
+        postalCode: 'SW1A 1AA',
+        country: 'GB',
+        username: null,
+      },
+      fields: null,
+    };
+
+    const result = parseBitwardenItem(item, folderMap);
+
+    expect(result.type).toBe('identity');
+    expect(result.identity_first_name).toBe('Oliver');
+    expect(result.identity_email).toBe('oliver@example.com');
+    expect(result.identity_phone).toBe('+441234567890');
+    expect(result.identity_address).toBe('123 Main St, London, SW1A 1AA, GB');
+  });
+});

--- a/src/pages/tools/password-migration/index.astro
+++ b/src/pages/tools/password-migration/index.astro
@@ -1,0 +1,16 @@
+---
+// Full-page SPA — no Astro layout
+---
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Password Migration Helper</title>
+</head>
+<body class="bg-gray-50 dark:bg-gray-900 min-h-screen">
+  <div id="app"></div>
+  <script>
+    import './_app/app.jsx';
+  </script>
+</body>
+</html>

--- a/src/pages/tools/password-migration/spec.allium
+++ b/src/pages/tools/password-migration/spec.allium
@@ -1,0 +1,336 @@
+-- allium: 2
+-- password-migration.allium
+
+-- Scope: Audit and track migration of Bitwarden vault entries
+--        to Apple Passwords and Uplock
+-- Includes: Import, entry tracking, field-level disposition, progress
+-- Excludes:
+--   - Generating import files for target apps
+--   - Automatic verification against target app exports
+--   - Bulk operations
+-- Dependencies: None (standalone client-side tool)
+
+------------------------------------------------------------
+-- Enumerations
+------------------------------------------------------------
+
+enum BitwardenItemType { login | secure_note | card | identity }
+
+enum EntryDisposition { apple_passwords | uplock | apple_wallet | deleted }
+-- Cards can go to Apple Wallet or Uplock, user decides per entry
+
+enum FieldStatus { migrated | discarded }
+
+------------------------------------------------------------
+-- Value Types
+------------------------------------------------------------
+
+value CustomField {
+    name: String
+    value: String
+    is_hidden: Boolean
+}
+
+value Attachment {
+    filename: String
+    content: String?
+    -- content is null for binary files (e.g., .p12)
+    is_binary: Boolean
+}
+
+value Uri {
+    uri: String
+}
+
+------------------------------------------------------------
+-- Entities
+------------------------------------------------------------
+
+-- The imported Bitwarden vault, loaded once from a .zip export
+entity Vault {
+    entries: VaultEntry with vault = this
+
+    -- Derived
+    total_count: entries.count
+    done_count: entries where disposition != null -> count
+    remaining_count: total_count - done_count
+}
+
+entity VaultEntry {
+    vault: Vault
+
+    -- Bitwarden source data (immutable after import)
+    bitwarden_id: String
+    name: String
+    type: BitwardenItemType
+    notes: String?
+    is_favorite: Boolean
+    folder_name: String?
+    -- Read-only context from Bitwarden, not used by target apps
+
+    -- Login fields (present when type = login)
+    uris: List<Uri>
+    username: String?
+    password: String?
+    totp: String?
+
+    -- Card fields (present when type = card)
+    cardholder_name: String?
+    card_brand: String?
+    card_number: String?
+    card_exp_month: String?
+    card_exp_year: String?
+    card_code: String?
+
+    -- Identity fields (present when type = identity)
+    identity_title: String?
+    identity_first_name: String?
+    identity_last_name: String?
+    identity_email: String?
+    identity_phone: String?
+    identity_address: String?
+
+    -- Custom fields and attachments
+    custom_fields: List<CustomField>
+    attachments: List<Attachment>
+
+    -- User-controlled migration state
+    disposition: EntryDisposition?
+    user_notes: String?
+    is_pinned: Boolean
+
+    -- Field-level tracking
+    field_statuses: FieldTracking with entry = this
+
+    -- Derived
+    is_done: disposition != null
+    has_custom_fields: custom_fields.count > 0
+    has_totp: totp != null
+    has_attachments: attachments.count > 0
+    has_sensitive_extras: has_custom_fields or has_totp or has_attachments
+}
+
+-- Tracks disposition of individual fields within an entry.
+-- This is for the user's own progress tracking only.
+-- Field tracking does NOT gate whether an entry is considered "done" —
+-- only the entry-level disposition determines that.
+entity FieldTracking {
+    entry: VaultEntry
+
+    totp_status: FieldStatus?
+    notes_status: FieldStatus?
+    custom_field_statuses: List<FieldStatus?>
+    -- Parallel to entry.custom_fields by index
+    attachment_statuses: List<FieldStatus?>
+    -- Parallel to entry.attachments by index
+}
+
+-- Manual checksum input from Apple Passwords
+entity ApplePasswordsChecksum {
+    reported_count: Integer
+    -- User types in how many entries Apple Passwords says it has
+}
+
+------------------------------------------------------------
+-- Rules
+------------------------------------------------------------
+
+-- ## Import flow
+
+rule ImportVault {
+    when: UserUploadsZip(file)
+
+    ensures: Vault.created(
+        -- Parse data.json from zip, create VaultEntry per item
+        -- Extract attachment file contents where readable
+    )
+
+    @guidance
+        -- Parse the .zip client-side using JSZip or similar
+        -- data.json contains the Bitwarden JSON export
+        -- Attachment files are in the zip alongside data.json
+        -- Binary files (e.g., .p12) should be marked is_binary = true
+        -- All data stored in localStorage, never sent to a server
+}
+
+-- ## Entry disposition
+
+rule SetEntryDisposition {
+    when: UserSetsDisposition(entry, disposition)
+
+    ensures: entry.disposition = disposition
+}
+
+rule ClearEntryDisposition {
+    when: UserClearsDisposition(entry)
+
+    ensures: entry.disposition = null
+}
+
+rule PinEntry {
+    when: UserPinsEntry(entry)
+
+    -- Only one entry can be pinned at a time
+    requires: Vault.entries where is_pinned = true -> count <= 1
+
+    ensures: entry.is_pinned = true
+    ensures:
+        for other in Vault.entries where is_pinned = true and bitwarden_id != entry.bitwarden_id:
+            other.is_pinned = false
+}
+
+rule UnpinEntry {
+    when: UserUnpinsEntry(entry)
+
+    ensures: entry.is_pinned = false
+}
+
+-- ## Field tracking
+
+rule SetFieldStatus {
+    when: UserSetsFieldStatus(entry, field_name, status)
+
+    ensures: entry.field_statuses updated for field_name with status
+
+    @guidance
+        -- field_name identifies which field: "totp", "notes",
+        -- "custom_field_0", "custom_field_1", "attachment_0", etc.
+}
+
+-- ## Notes
+
+rule UpdateUserNotes {
+    when: UserUpdatesNotes(entry, text)
+
+    ensures: entry.user_notes = text
+}
+
+-- ## Checksum
+
+rule SetApplePasswordsCount {
+    when: UserEntersApplePasswordsCount(count)
+
+    ensures: ApplePasswordsChecksum.reported_count = count
+}
+
+-- ## Reset
+
+rule ResetAll {
+    when: UserResetsVault
+
+    ensures: Vault deleted
+    ensures: all VaultEntries deleted
+    ensures: all FieldTrackings deleted
+    ensures: ApplePasswordsChecksum deleted
+    ensures: localStorage cleared for this tool
+
+    @guidance
+        -- Requires explicit confirmation from the user
+        -- This is the only way to start over or re-import
+}
+
+------------------------------------------------------------
+-- Invariants
+------------------------------------------------------------
+
+invariant EveryEntryAccountedFor {
+    -- The goal of the tool: when remaining_count = 0,
+    -- every Bitwarden entry has a disposition
+    for entry in Vault.entries:
+        entry.is_done = (entry.disposition != null)
+}
+
+invariant SinglePinnedEntry {
+    -- At most one entry is pinned at any time
+    Vault.entries where is_pinned = true -> count <= 1
+}
+
+invariant DataNeverLeavesClient {
+    -- All vault data, disposition state, and user notes
+    -- are stored exclusively in browser localStorage.
+    -- No network requests are made with vault data.
+}
+
+------------------------------------------------------------
+-- Actor Declarations
+------------------------------------------------------------
+
+actor User {}
+
+------------------------------------------------------------
+-- Surfaces
+------------------------------------------------------------
+
+surface MigrationUI {
+    facing user: User
+
+    -- Upload
+    provides: upload_zip
+        -- File picker for .zip, disabled once vault is loaded
+
+    -- Progress dashboard
+    exposes: vault.total_count, vault.done_count, vault.remaining_count
+    exposes: apple_passwords_checksum.reported_count
+    exposes: apple_passwords_marked_count
+        -- Count of entries with disposition = apple_passwords and is_done
+    exposes: checksum_delta
+        -- apple_passwords_checksum.reported_count - apple_passwords_marked_count
+
+    -- Entry list
+    exposes: active_entries
+        -- Entries where disposition = null, with pinned entry first
+    exposes: done_entries
+        -- Entries where disposition != null, greyed out
+    exposes: search and filter controls
+        -- Text search on name/URIs, filter by type, filter by status
+
+    -- Entry detail (expanded/pinned view)
+    exposes: entry source data
+        -- All Bitwarden fields for the entry
+        -- Passwords, TOTP, hidden custom fields, attachment contents
+        -- behind click-to-reveal
+    provides: set_disposition, clear_disposition
+    provides: pin_entry, unpin_entry
+    provides: set_field_status for each trackable field
+    provides: update_user_notes
+    provides: enter_apple_passwords_count
+
+    -- Reset
+    provides: reset_vault
+        -- Clears all data, returns to upload screen
+        -- Requires confirmation
+
+    @guidance
+        -- Active entries are the primary focus area of the UI
+        -- Done entries are visually de-emphasised (greyed out)
+        -- The pinned entry appears expanded at the top with full detail
+        -- Clicking an unpinned entry pins it and expands it
+        -- Sensitive fields (password, TOTP, hidden custom fields,
+        -- attachment contents) are behind click-to-reveal
+        -- Attachments show filename always; content revealed on click
+        -- Binary attachments just show filename and a note
+        -- Bitwarden folder name shown as a read-only label on each entry
+}
+
+------------------------------------------------------------
+-- Resolved Decisions
+------------------------------------------------------------
+
+-- Cards: can go to Apple Wallet or Uplock, user decides per entry
+-- Folder names: shown as read-only labels for context
+-- Field tracking: progress aid only, does not gate entry completion
+-- Login extras (custom fields, backup codes, API keys): user handles
+--   per-field via field tracking — options are put in Apple Passwords
+--   notes field, create separate Uplock entry, or discard. The tool
+--   surfaces the fields and tracks their status, no automation.
+-- Re-import: not supported. Reset and start over is the only option.
+-- Sensitive data: all behind click-to-reveal (passwords, TOTP,
+--   hidden custom fields, attachment contents)
+
+------------------------------------------------------------
+-- Open Questions
+------------------------------------------------------------
+
+open question "Should the entry list show a visual indicator when an entry has untracked fields, even though it doesn't block completion?"
+
+open question "For the ~580 entries, is alphabetical sort sufficient or would sort by type / sort by has-extras be useful?"


### PR DESCRIPTION
## Summary
- Client-side React SPA for auditing and tracking migration of a Bitwarden vault to Apple Passwords, Uplock, and Apple Wallet
- Parses Bitwarden .zip exports entirely in-browser — no data sent externally
- Sensitive vault data in sessionStorage (dies with tab), non-sensitive progress in localStorage (persists)
- Per-entry disposition tracking (Apple Passwords / Uplock / Apple Wallet / Deleted)
- Field-level status tracking for TOTP, custom fields, and attachments
- Click-to-reveal for passwords, TOTP, notes, and hidden fields
- Table layout with accordion detail panel, search across name/username/URL/folder/password
- Progress dashboard with Apple Passwords checksum comparison
- Graceful degradation when vault not loaded (shows entry names and progress from manifest)
- 30 tests (Vitest + Testing Library)

## Test plan
- [ ] `npm run build && npm run preview` — verify tool loads at `/tools/password-migration/`
- [ ] Upload a Bitwarden .zip export, confirm entries appear in table
- [ ] Click an entry — detail panel opens inline (accordion)
- [ ] Set dispositions, verify progress bar updates
- [ ] Close tab, reopen — progress preserved, vault cleared, re-upload banner shown
- [ ] Click Reset — all data cleared
- [ ] `npx vitest run src/pages/tools/password-migration/` — 30 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)