### PR TITLE
Add XDB benchmark dashboard data validation app

### DIFF
--- a/src/content/tools/xdb-benchmarks.json
+++ b/src/content/tools/xdb-benchmarks.json
@@ -1,0 +1,5 @@
+{
+  "title": "XTDB Benchmark Dashboard",
+  "date": "2026-03-20",
+  "description": "Query and visualise XTDB nightly benchmark runs from GitHub Actions and Azure Log Analytics."
+}

--- a/src/pages/tools/xdb-benchmarks/_app/app.css
+++ b/src/pages/tools/xdb-benchmarks/_app/app.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/src/pages/tools/xdb-benchmarks/_app/app.jsx
+++ b/src/pages/tools/xdb-benchmarks/_app/app.jsx
@@ -1,0 +1,441 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { createRoot } from 'react-dom/client';
+import { fetchAllBenchmarkRuns, BENCHMARK_WORKFLOWS } from './github.js';
+import {
+  queryLogAnalytics,
+  getWorkspaceId,
+  laResultToRows,
+  SAMPLE_QUERIES,
+  WORKSPACE_NAME,
+} from './azure.js';
+
+// ── Small UI primitives ────────────────────────────────────────────────────
+
+function Card({ children, className = '' }) {
+  return (
+    <div className={`bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 ${className}`}>
+      {children}
+    </div>
+  );
+}
+
+function Badge({ label, variant = 'gray' }) {
+  const colors = {
+    success: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+    failure: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+    gray:    'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+    blue:    'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+    yellow:  'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+  };
+  return (
+    <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${colors[variant]}`}>
+      {label}
+    </span>
+  );
+}
+
+function conclusionBadge(conclusion) {
+  if (conclusion === 'success') return <Badge label="success" variant="success" />;
+  if (conclusion === 'failure') return <Badge label="failure" variant="failure" />;
+  if (!conclusion) return <Badge label="running" variant="yellow" />;
+  return <Badge label={conclusion} variant="gray" />;
+}
+
+function eventBadge(event) {
+  if (event === 'schedule') return <Badge label="nightly" variant="blue" />;
+  if (event === 'workflow_dispatch') return <Badge label="manual" variant="gray" />;
+  return <Badge label={event} variant="gray" />;
+}
+
+function fmtDate(iso) {
+  return new Date(iso).toLocaleString(undefined, {
+    month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+  });
+}
+
+// ── GitHub runs section ────────────────────────────────────────────────────
+
+function WorkflowRunsTable({ wf, runs }) {
+  const [expanded, setExpanded] = useState(false);
+  const visible = expanded ? runs : runs.slice(0, 5);
+  return (
+    <div className="mb-4">
+      <h3 className="font-semibold text-sm mb-2 text-gray-700 dark:text-gray-300">
+        {wf.name}
+      </h3>
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+              <th className="py-1 pr-3">Date</th>
+              <th className="py-1 pr-3">Trigger</th>
+              <th className="py-1 pr-3">Result</th>
+              <th className="py-1 pr-3">Branch</th>
+              <th className="py-1">Run ID</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visible.map(r => (
+              <tr key={r.id} className="border-b border-gray-100 dark:border-gray-700/50">
+                <td className="py-1 pr-3 text-gray-600 dark:text-gray-400 whitespace-nowrap">
+                  {fmtDate(r.createdAt)}
+                </td>
+                <td className="py-1 pr-3">{eventBadge(r.event)}</td>
+                <td className="py-1 pr-3">{conclusionBadge(r.conclusion)}</td>
+                <td className="py-1 pr-3 text-gray-600 dark:text-gray-400 font-mono">{r.headBranch}</td>
+                <td className="py-1">
+                  <a href={r.htmlUrl} target="_blank" rel="noreferrer"
+                     className="text-blue-600 dark:text-blue-400 hover:underline font-mono">
+                    #{r.runNumber}
+                  </a>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {runs.length > 5 && (
+        <button onClick={() => setExpanded(!expanded)}
+                className="text-xs text-blue-600 dark:text-blue-400 hover:underline mt-1">
+          {expanded ? 'Show less' : `Show all ${runs.length} runs`}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function GitHubSection() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchAllBenchmarkRuns({ perPage: 14 });
+      setData(result);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return (
+    <Card className="mb-6">
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            GitHub Actions — Benchmark Runs
+          </h2>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            Public API · xtdb/xtdb · No auth required
+          </p>
+        </div>
+        <button onClick={load} disabled={loading}
+                className="px-3 py-1.5 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm rounded-md">
+          {loading ? 'Loading…' : data ? 'Refresh' : 'Fetch Runs'}
+        </button>
+      </div>
+
+      {error && (
+        <div className="text-red-600 dark:text-red-400 text-sm bg-red-50 dark:bg-red-900/20 rounded p-3 mb-4">
+          {error}
+        </div>
+      )}
+
+      {data && (
+        <div>
+          {data.map(({ workflow: wf, runs, error: wfErr }) => (
+            <div key={wf.id}>
+              {wfErr ? (
+                <p className="text-xs text-red-500 mb-2">{wf.name}: {wfErr}</p>
+              ) : (
+                <WorkflowRunsTable wf={wf} runs={runs} />
+              )}
+            </div>
+          ))}
+          <div className="mt-3 p-3 bg-gray-50 dark:bg-gray-700/50 rounded text-xs text-gray-600 dark:text-gray-400">
+            <strong>What we get:</strong> Run IDs, dates, trigger type (nightly schedule vs manual),
+            branch, status. The run ID links benchmark runs to Log Analytics log entries
+            via the <code>github-run-id</code> field.
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}
+
+// ── Azure Log Analytics section ────────────────────────────────────────────
+
+function AzureSection() {
+  const [token, setToken] = useState('');
+  const [workspaceId, setWorkspaceId] = useState('');
+  const [resolving, setResolving] = useState(false);
+  const [resolveError, setResolveError] = useState(null);
+  const [selectedQuery, setSelectedQuery] = useState('overview');
+  const [customKql, setCustomKql] = useState('');
+  const [queryResult, setQueryResult] = useState(null);
+  const [queryError, setQueryError] = useState(null);
+  const [querying, setQuerying] = useState(false);
+
+  const resolveWorkspace = useCallback(async () => {
+    if (!token) return;
+    setResolving(true);
+    setResolveError(null);
+    try {
+      const id = await getWorkspaceId(token);
+      if (!id) throw new Error('Could not find workspace ID in response');
+      setWorkspaceId(id);
+    } catch (e) {
+      setResolveError(e.message);
+    } finally {
+      setResolving(false);
+    }
+  }, [token]);
+
+  const runQuery = useCallback(async () => {
+    if (!token || !workspaceId) return;
+    setQuerying(true);
+    setQueryError(null);
+    setQueryResult(null);
+    const kql = selectedQuery === 'custom'
+      ? customKql
+      : SAMPLE_QUERIES[selectedQuery];
+    try {
+      const raw = await queryLogAnalytics(workspaceId, kql, token);
+      const rows = laResultToRows(raw);
+      setQueryResult({ raw, rows });
+    } catch (e) {
+      setQueryError(e.message);
+    } finally {
+      setQuerying(false);
+    }
+  }, [token, workspaceId, selectedQuery, customKql]);
+
+  return (
+    <Card className="mb-6">
+      <div className="mb-4">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          Azure Log Analytics — Benchmark Metrics
+        </h2>
+        <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+          Workspace: <code className="font-mono">{WORKSPACE_NAME}</code> · Requires Azure token
+        </p>
+      </div>
+
+      {/* Token input */}
+      <div className="mb-4">
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          Azure Bearer Token
+        </label>
+        <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+          Get one with:{' '}
+          <code className="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">
+            az account get-access-token --resource https://api.loganalytics.io --query accessToken -o tsv
+          </code>
+        </p>
+        <textarea
+          className="w-full h-20 font-mono text-xs border border-gray-300 dark:border-gray-600 rounded p-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 resize-none"
+          placeholder="eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik..."
+          value={token}
+          onChange={e => setToken(e.target.value.trim())}
+        />
+      </div>
+
+      {/* Workspace ID */}
+      <div className="mb-4">
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          Workspace GUID
+        </label>
+        <div className="flex gap-2">
+          <input
+            className="flex-1 font-mono text-xs border border-gray-300 dark:border-gray-600 rounded p-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+            placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+            value={workspaceId}
+            onChange={e => setWorkspaceId(e.target.value.trim())}
+          />
+          <button onClick={resolveWorkspace} disabled={!token || resolving}
+                  className="px-3 py-1.5 bg-gray-600 hover:bg-gray-700 disabled:opacity-50 text-white text-sm rounded-md whitespace-nowrap">
+            {resolving ? 'Resolving…' : 'Resolve from token'}
+          </button>
+        </div>
+        {resolveError && (
+          <p className="text-xs text-red-500 mt-1">{resolveError}</p>
+        )}
+        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+          Or get it with:{' '}
+          <code className="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">
+            az monitor log-analytics workspace show --workspace-name {WORKSPACE_NAME} --resource-group cloud-benchmark-resources --query customerId -o tsv
+          </code>
+        </p>
+      </div>
+
+      {/* Query selector */}
+      <div className="mb-4">
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+          Sample Query
+        </label>
+        <div className="flex flex-wrap gap-2 mb-3">
+          {Object.keys(SAMPLE_QUERIES).map(k => (
+            <button key={k} onClick={() => setSelectedQuery(k)}
+                    className={`px-3 py-1 text-sm rounded-md border ${
+                      selectedQuery === k
+                        ? 'bg-blue-600 text-white border-blue-600'
+                        : 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+                    }`}>
+              {k}
+            </button>
+          ))}
+          <button onClick={() => setSelectedQuery('custom')}
+                  className={`px-3 py-1 text-sm rounded-md border ${
+                    selectedQuery === 'custom'
+                      ? 'bg-blue-600 text-white border-blue-600'
+                      : 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+                  }`}>
+            custom
+          </button>
+        </div>
+
+        <pre className={`text-xs font-mono bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded p-3 overflow-x-auto whitespace-pre-wrap ${selectedQuery === 'custom' ? 'hidden' : ''}`}>
+          {SAMPLE_QUERIES[selectedQuery]}
+        </pre>
+
+        {selectedQuery === 'custom' && (
+          <textarea
+            className="w-full h-40 font-mono text-xs border border-gray-300 dark:border-gray-600 rounded p-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 resize-y"
+            placeholder="ContainerLog | ..."
+            value={customKql}
+            onChange={e => setCustomKql(e.target.value)}
+          />
+        )}
+      </div>
+
+      <button onClick={runQuery} disabled={!token || !workspaceId || querying}
+              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm rounded-md mb-4">
+        {querying ? 'Querying…' : 'Run Query'}
+      </button>
+
+      {queryError && (
+        <div className="text-red-600 dark:text-red-400 text-sm bg-red-50 dark:bg-red-900/20 rounded p-3 mb-4">
+          {queryError}
+        </div>
+      )}
+
+      {queryResult && (
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+              Results — {queryResult.rows.length} rows
+            </h3>
+          </div>
+
+          {queryResult.rows.length > 0 ? (
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+                    {Object.keys(queryResult.rows[0]).map(col => (
+                      <th key={col} className="py-1 pr-3 font-medium">{col}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {queryResult.rows.map((row, i) => (
+                    <tr key={i} className="border-b border-gray-100 dark:border-gray-700/50">
+                      {Object.values(row).map((val, j) => (
+                        <td key={j} className="py-1 pr-3 text-gray-600 dark:text-gray-400 font-mono">
+                          {typeof val === 'number' ? val.toFixed(3) : String(val ?? '')}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="text-sm text-gray-500 dark:text-gray-400">No rows returned.</p>
+          )}
+
+          <details className="mt-3">
+            <summary className="text-xs text-gray-500 cursor-pointer hover:text-gray-700 dark:hover:text-gray-300">
+              Raw JSON response
+            </summary>
+            <pre className="text-xs font-mono bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded p-3 mt-2 overflow-x-auto max-h-64">
+              {JSON.stringify(queryResult.raw, null, 2)}
+            </pre>
+          </details>
+        </div>
+      )}
+    </Card>
+  );
+}
+
+// ── Data architecture notes ────────────────────────────────────────────────
+
+function ArchitectureCard() {
+  return (
+    <Card className="mb-6">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">
+        Data Architecture
+      </h2>
+      <div className="text-sm text-gray-600 dark:text-gray-400 space-y-2">
+        <p>
+          <strong className="text-gray-800 dark:text-gray-200">Benchmark runs</strong>
+          {' '}deploy on Azure Kubernetes via Helm. Each benchmark binary outputs structured
+          JSON logs that get shipped to <strong className="text-gray-800 dark:text-gray-200">Azure Log Analytics</strong>
+          {' '}(ContainerLog table).
+        </p>
+        <p>
+          <strong className="text-gray-800 dark:text-gray-200">Log entry schema:</strong>
+          {' '}Each entry has <code className="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">benchmark</code>,{' '}
+          <code className="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">step</code>,{' '}
+          <code className="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">metric</code>,{' '}
+          <code className="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">time-taken-ms</code>,{' '}
+          <code className="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">github-run-id</code>,{' '}
+          <code className="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">git-branch</code>,{' '}
+          plus benchmark-specific <code className="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">parameters</code>.
+        </p>
+        <p>
+          <strong className="text-gray-800 dark:text-gray-200">Linking:</strong>
+          {' '}GitHub run IDs from the Actions API can be cross-referenced with
+          {' '}<code className="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">log['github-run-id']</code>
+          {' '}in Log Analytics to join run metadata (trigger type, date) with actual metrics.
+        </p>
+        <p>
+          <strong className="text-gray-800 dark:text-gray-200">Nightly vs manual:</strong>
+          {' '}GitHub Actions <code className="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">event</code>
+          {' '}field distinguishes <code className="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">schedule</code>
+          {' '}(nightly) from <code className="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">workflow_dispatch</code>
+          {' '}(manual) runs — exactly what's needed to filter "daily runs" vs one-off comparisons.
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+// ── Root ───────────────────────────────────────────────────────────────────
+
+function App() {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white">
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <div className="mb-8">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+            XTDB Benchmark Dashboard — Data Validation
+          </h1>
+          <p className="text-gray-500 dark:text-gray-400 mt-1">
+            Validates that benchmark data can be queried from the browser.
+          </p>
+        </div>
+
+        <ArchitectureCard />
+        <GitHubSection />
+        <AzureSection />
+      </div>
+    </div>
+  );
+}
+
+createRoot(document.getElementById('app')).render(<App />);

--- a/src/pages/tools/xdb-benchmarks/_app/app.jsx
+++ b/src/pages/tools/xdb-benchmarks/_app/app.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { createRoot } from 'react-dom/client';
+import './app.css';
 import { fetchAllBenchmarkRuns, BENCHMARK_WORKFLOWS } from './github.js';
 import {
   queryLogAnalytics,

--- a/src/pages/tools/xdb-benchmarks/_app/azure.js
+++ b/src/pages/tools/xdb-benchmarks/_app/azure.js
@@ -1,0 +1,105 @@
+// Azure Log Analytics query helpers
+
+// Public info from xtdb/xtdb repo (terraform.tfvars + main.tf)
+export const WORKSPACE_NAME = 'xtdb-bench-cluster-law';
+export const RESOURCE_GROUP = 'cloud-benchmark-resources';
+export const SUBSCRIPTION_ID = '91804669-c60b-4727-afa2-d7021fe5055b';
+
+// Get a token via: az account get-access-token --resource https://api.loganalytics.io --query accessToken -o tsv
+const LA_API = 'https://api.loganalytics.io/v1';
+
+export async function queryLogAnalytics(workspaceId, kql, token, { timespan = 'P14D' } = {}) {
+  const url = `${LA_API}/workspaces/${workspaceId}/query`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query: kql, timespan }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Log Analytics ${res.status}: ${text}`);
+  }
+  return res.json();
+}
+
+// Convert LA query result to array of objects
+export function laResultToRows(result) {
+  const table = result?.tables?.[0];
+  if (!table) return [];
+  const cols = table.columns.map(c => c.name);
+  return table.rows.map(row =>
+    Object.fromEntries(cols.map((col, i) => [col, row[i]]))
+  );
+}
+
+// Get workspace GUID from Azure Management API (needs management token)
+export async function getWorkspaceId(token) {
+  const url = `https://management.azure.com/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.OperationalInsights/workspaces/${WORKSPACE_NAME}?api-version=2023-09-01`;
+  const res = await fetch(url, {
+    headers: { 'Authorization': `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Management API ${res.status}: ${text}`);
+  }
+  const data = await res.json();
+  return data.properties?.customerId;
+}
+
+// Sample KQL queries for each benchmark type
+export const SAMPLE_QUERIES = {
+  overview: `
+ContainerLog
+| where LogEntry startswith "{"
+| extend log = parse_json(LogEntry)
+| where isnotnull(log.benchmark) and log.stage != "init"
+| extend benchmark = tostring(log.benchmark),
+         run_id = tostring(log['github-run-id']),
+         branch = tostring(log['git-branch']),
+         duration_ms = todouble(log['time-taken-ms'])
+| where branch == "main"
+| summarize TimeGenerated = max(TimeGenerated),
+            duration_ms = avg(duration_ms)
+    by run_id, benchmark
+| order by TimeGenerated desc
+| take 100
+`.trim(),
+
+  tpch: `
+ContainerLog
+| where LogEntry startswith "{"
+| extend log = parse_json(LogEntry)
+| where isnotnull(log.benchmark) and log.stage != "init"
+| extend benchmark = tostring(log.benchmark),
+         scale_factor = todouble(log.parameters['scale-factor']),
+         run_id = tostring(log['github-run-id']),
+         branch = tostring(log['git-branch']),
+         duration_ms = todouble(log['time-taken-ms'])
+| where benchmark == "TPC-H (OLAP)" and scale_factor == 1.0 and branch == "main"
+| summarize TimeGenerated = max(TimeGenerated),
+            duration_minutes = avg(duration_ms) / 60000
+    by run_id
+| top 30 by TimeGenerated desc
+| order by TimeGenerated asc
+`.trim(),
+
+  clickbench: `
+ContainerLog
+| where LogEntry startswith "{"
+| extend log = parse_json(LogEntry)
+| where isnotnull(log.benchmark) and log.stage != "init"
+| extend benchmark = tostring(log.benchmark),
+         run_id = tostring(log['github-run-id']),
+         branch = tostring(log['git-branch']),
+         duration_ms = todouble(log['time-taken-ms'])
+| where benchmark == "Clickbench Hits" and branch == "main"
+| summarize TimeGenerated = max(TimeGenerated),
+            duration_minutes = avg(duration_ms) / 60000
+    by run_id
+| top 30 by TimeGenerated desc
+| order by TimeGenerated asc
+`.trim(),
+};

--- a/src/pages/tools/xdb-benchmarks/_app/github.js
+++ b/src/pages/tools/xdb-benchmarks/_app/github.js
@@ -1,0 +1,63 @@
+// GitHub Actions API helpers for xtdb/xtdb benchmark workflows
+
+const REPO = 'xtdb/xtdb';
+const BASE = 'https://api.github.com';
+
+// Nightly benchmark workflow IDs
+export const BENCHMARK_WORKFLOWS = [
+  { id: 210169003, name: 'AuctionMark',       key: 'auctionmark' },
+  { id: 214460250, name: 'ClickBench',         key: 'clickbench' },
+  { id: 232672058, name: 'Fusion',             key: 'fusion' },
+  { id: 223619706, name: 'Ingest TX Overhead', key: 'ingest-tx-overhead' },
+  { id: 225012787, name: 'Patch',              key: 'patch' },
+  { id: 225012788, name: 'Products',           key: 'products' },
+  { id: 208760327, name: 'Readings',           key: 'readings' },
+  { id: 186222960, name: 'TPC-H',              key: 'tpch' },
+  { id: 225012789, name: 'TS Devices',         key: 'ts-devices' },
+  { id: 221112688, name: 'TSBS IoT',           key: 'tsbs-iot' },
+  { id: 204249915, name: 'Yakbench',           key: 'yakbench' },
+];
+
+async function ghFetch(path, params = {}) {
+  const url = new URL(`${BASE}${path}`);
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  const res = await fetch(url, {
+    headers: { 'Accept': 'application/vnd.github+json' },
+  });
+  if (!res.ok) throw new Error(`GitHub API ${res.status}: ${path}`);
+  return res.json();
+}
+
+export async function fetchWorkflowRuns(workflowId, { perPage = 30 } = {}) {
+  const data = await ghFetch(`/repos/${REPO}/actions/workflows/${workflowId}/runs`, {
+    per_page: perPage,
+    exclude_pull_requests: true,
+  });
+  return data.workflow_runs.map(r => ({
+    id: r.id,
+    runNumber: r.run_number,
+    status: r.status,
+    conclusion: r.conclusion,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+    event: r.event,           // 'schedule' | 'workflow_dispatch' | etc.
+    headBranch: r.head_branch,
+    headSha: r.head_sha,
+    htmlUrl: r.html_url,
+    name: r.display_title || r.name,
+  }));
+}
+
+export async function fetchAllBenchmarkRuns({ perPage = 14 } = {}) {
+  const results = await Promise.allSettled(
+    BENCHMARK_WORKFLOWS.map(async wf => ({
+      workflow: wf,
+      runs: await fetchWorkflowRuns(wf.id, { perPage }),
+    }))
+  );
+  return results.map((r, i) => ({
+    workflow: BENCHMARK_WORKFLOWS[i],
+    runs: r.status === 'fulfilled' ? r.value.runs : [],
+    error: r.status === 'rejected' ? r.reason.message : null,
+  }));
+}

--- a/src/pages/tools/xdb-benchmarks/index.astro
+++ b/src/pages/tools/xdb-benchmarks/index.astro
@@ -1,0 +1,16 @@
+---
+// Full-page SPA — no Astro layout
+---
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>XTDB Benchmark Dashboard</title>
+</head>
+<body class="bg-gray-50 dark:bg-gray-900 min-h-screen">
+  <div id="app"></div>
+  <script>
+    import './_app/app.jsx';
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Validates that XTDB benchmark data can be queried from the browser via two sources:
- GitHub Actions API (public): lists all nightly benchmark workflow runs with dates, trigger type (schedule vs manual), branch, and status
- Azure Log Analytics API (bearer token): queries ContainerLog table for actual benchmark metrics (time-taken-ms, throughput) using the KQL queries mirrored from the xtdb/xtdb metrics Terraform config

Includes architecture overview explaining how github-run-id links the two data sources together, and sample KQL queries for overview, TPC-H, and ClickBench benchmarks.

https://claude.ai/code/session_01Pq9QwFFUAEjFDhNLde6yVV