### PR TITLE
Add diff comparison tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,10 @@ Two collections, rendered together on the front page:
 
 - `title`, `stage` (scribble/draft/tale), `date`, `updated`, `tags`, `pinned`
 - Stage prefix ("A scribble:", etc.) is added at render time, not in the data.
+- **Stages** (see `content/notes/stages.md`):
+  - **scribble** — quickly jotted down, unpolished. Tools may have bugs.
+  - **draft** — more thought than the initial idea, but not confident enough to show around.
+  - **tale** — significant thought and effort; happy to share. May still evolve over time.
 
 ## Apps
 
@@ -65,3 +69,7 @@ All apps are built through Astro's Vite pipeline — no separate build step need
 - [Squint](https://github.com/squint-cljs/squint) - ClojureScript to JS compiler (via Vite plugin)
 - React - UI for some apps
 - Tailwind CSS 4 - Styling
+
+## Git
+
+- Default branch: `master`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "blog-by-the-rocks",
+  "name": "by-the-rocks",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "blog-by-the-rocks",
+      "name": "by-the-rocks",
       "version": "1.0.0",
       "dependencies": {
         "@astrojs/mdx": "^4.3.13",

--- a/src/content/works/diff-comparison.json
+++ b/src/content/works/diff-comparison.json
@@ -1,0 +1,10 @@
+{
+  "title": "Diff Comparison",
+  "stage": "draft",
+  "date": "2026-03-24",
+  "description": "Compare two texts side by side and view their differences as a combined or split diff.",
+  "tags": [
+    "tool",
+    "text"
+  ]
+}

--- a/src/pages/diff-comparison/_app/app.css
+++ b/src/pages/diff-comparison/_app/app.css
@@ -1,0 +1,20 @@
+@import "tailwindcss";
+
+.diff-line-delete {
+  @apply bg-red-100 dark:bg-red-950;
+}
+.diff-line-insert {
+  @apply bg-green-100 dark:bg-green-950;
+}
+.diff-line-equal {
+  @apply bg-transparent;
+}
+.diff-gutter {
+  @apply select-none text-gray-400 dark:text-gray-600 text-right pr-2 w-10 shrink-0 font-mono text-sm;
+}
+.diff-content {
+  @apply font-mono text-sm whitespace-pre pl-2 flex-1 min-w-0;
+}
+.diff-prefix {
+  @apply select-none text-gray-500 dark:text-gray-500 inline-block w-4;
+}

--- a/src/pages/diff-comparison/_app/app.jsx
+++ b/src/pages/diff-comparison/_app/app.jsx
@@ -1,0 +1,242 @@
+import React, { useState, useMemo } from 'react';
+import { createRoot } from 'react-dom/client';
+import { computeDiff } from './diff.js';
+import './app.css';
+
+const SAMPLE_LEFT = `function greet(name) {
+  console.log("Hello, " + name);
+  return true;
+}
+
+greet("world");`;
+
+const SAMPLE_RIGHT = `function greet(name, greeting) {
+  const message = greeting + ", " + name + "!";
+  console.log(message);
+  return message;
+}
+
+greet("world", "Hi");`;
+
+function CombinedView({ edits }) {
+  if (edits.length === 0) {
+    return <p className="text-gray-500 dark:text-gray-400 p-4 italic">No differences.</p>;
+  }
+
+  let oldNum = 0;
+  let newNum = 0;
+
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-auto">
+      {edits.map((edit, i) => {
+        let leftGutter = '';
+        let rightGutter = '';
+        let prefix = ' ';
+        let lineClass = 'diff-line-equal';
+
+        if (edit.type === 'equal') {
+          oldNum++;
+          newNum++;
+          leftGutter = oldNum;
+          rightGutter = newNum;
+        } else if (edit.type === 'delete') {
+          oldNum++;
+          leftGutter = oldNum;
+          prefix = '-';
+          lineClass = 'diff-line-delete';
+        } else {
+          newNum++;
+          rightGutter = newNum;
+          prefix = '+';
+          lineClass = 'diff-line-insert';
+        }
+
+        return (
+          <div key={i} className={`flex ${lineClass}`}>
+            <div className="diff-gutter border-r border-gray-200 dark:border-gray-700">{leftGutter}</div>
+            <div className="diff-gutter border-r border-gray-200 dark:border-gray-700">{rightGutter}</div>
+            <div className="diff-content">
+              <span className="diff-prefix">{prefix}</span>
+              {edit.value}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function SideBySideView({ edits }) {
+  if (edits.length === 0) {
+    return <p className="text-gray-500 dark:text-gray-400 p-4 italic">No differences.</p>;
+  }
+
+  // Build paired rows: each row has a left and/or right side
+  const rows = [];
+  let i = 0;
+  while (i < edits.length) {
+    if (edits[i].type === 'equal') {
+      rows.push({ left: edits[i], right: edits[i] });
+      i++;
+    } else {
+      // Collect consecutive deletes and inserts
+      const deletes = [];
+      const inserts = [];
+      while (i < edits.length && edits[i].type === 'delete') {
+        deletes.push(edits[i]);
+        i++;
+      }
+      while (i < edits.length && edits[i].type === 'insert') {
+        inserts.push(edits[i]);
+        i++;
+      }
+      const maxLen = Math.max(deletes.length, inserts.length);
+      for (let j = 0; j < maxLen; j++) {
+        rows.push({
+          left: j < deletes.length ? deletes[j] : null,
+          right: j < inserts.length ? inserts[j] : null,
+        });
+      }
+    }
+  }
+
+  let oldNum = 0;
+  let newNum = 0;
+
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-auto">
+      {rows.map((row, i) => {
+        let leftGutter = '';
+        let rightGutter = '';
+        let leftClass = 'diff-line-equal';
+        let rightClass = 'diff-line-equal';
+        let leftValue = '';
+        let rightValue = '';
+
+        if (row.left) {
+          if (row.left.type === 'equal') {
+            oldNum++;
+            leftGutter = oldNum;
+            leftValue = row.left.value;
+          } else if (row.left.type === 'delete') {
+            oldNum++;
+            leftGutter = oldNum;
+            leftClass = 'diff-line-delete';
+            leftValue = row.left.value;
+          }
+        }
+
+        if (row.right) {
+          if (row.right.type === 'equal') {
+            newNum++;
+            rightGutter = newNum;
+            rightValue = row.right.value;
+          } else if (row.right.type === 'insert') {
+            newNum++;
+            rightGutter = newNum;
+            rightClass = 'diff-line-insert';
+            rightValue = row.right.value;
+          }
+        }
+
+        return (
+          <div key={i} className="flex">
+            <div className={`flex flex-1 min-w-0 ${leftClass}`}>
+              <div className="diff-gutter border-r border-gray-200 dark:border-gray-700">{leftGutter}</div>
+              <div className="diff-content truncate">{leftValue}</div>
+            </div>
+            <div className="w-px bg-gray-300 dark:bg-gray-600 shrink-0" />
+            <div className={`flex flex-1 min-w-0 ${rightClass}`}>
+              <div className="diff-gutter border-r border-gray-200 dark:border-gray-700">{rightGutter}</div>
+              <div className="diff-content truncate">{rightValue}</div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function App() {
+  const [left, setLeft] = useState(SAMPLE_LEFT);
+  const [right, setRight] = useState(SAMPLE_RIGHT);
+  const [viewMode, setViewMode] = useState('combined');
+
+  const edits = useMemo(() => computeDiff(left, right), [left, right]);
+
+  const stats = useMemo(() => {
+    let added = 0, removed = 0;
+    for (const e of edits) {
+      if (e.type === 'insert') added++;
+      if (e.type === 'delete') removed++;
+    }
+    return { added, removed };
+  }, [edits]);
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">Diff Comparison</h1>
+
+      <div className="flex flex-col md:flex-row gap-4 mb-6">
+        <div className="flex-1 flex flex-col">
+          <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Original</label>
+          <textarea
+            className="w-full h-48 p-3 font-mono text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 resize-y focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none"
+            value={left}
+            onChange={(e) => setLeft(e.target.value)}
+            placeholder="Paste original text here..."
+            spellCheck={false}
+          />
+        </div>
+        <div className="flex-1 flex flex-col">
+          <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Modified</label>
+          <textarea
+            className="w-full h-48 p-3 font-mono text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 resize-y focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none"
+            value={right}
+            onChange={(e) => setRight(e.target.value)}
+            placeholder="Paste modified text here..."
+            spellCheck={false}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-4 mb-4">
+        <div className="flex bg-gray-200 dark:bg-gray-700 rounded-lg p-0.5">
+          <button
+            className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+              viewMode === 'combined'
+                ? 'bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-sm'
+                : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+            }`}
+            onClick={() => setViewMode('combined')}
+          >
+            Combined
+          </button>
+          <button
+            className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+              viewMode === 'side-by-side'
+                ? 'bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-sm'
+                : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+            }`}
+            onClick={() => setViewMode('side-by-side')}
+          >
+            Side by Side
+          </button>
+        </div>
+        <div className="text-sm text-gray-500 dark:text-gray-400">
+          {stats.added > 0 && <span className="text-green-600 dark:text-green-400 mr-2">+{stats.added}</span>}
+          {stats.removed > 0 && <span className="text-red-600 dark:text-red-400">-{stats.removed}</span>}
+          {stats.added === 0 && stats.removed === 0 && <span>No changes</span>}
+        </div>
+      </div>
+
+      {viewMode === 'combined' ? (
+        <CombinedView edits={edits} />
+      ) : (
+        <SideBySideView edits={edits} />
+      )}
+    </div>
+  );
+}
+
+createRoot(document.getElementById('app')).render(<App />);

--- a/src/pages/diff-comparison/_app/app.jsx
+++ b/src/pages/diff-comparison/_app/app.jsx
@@ -1,7 +1,9 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import { computeDiff } from './diff.js';
 import './app.css';
+
+const STORAGE_KEY = 'diff-comparison';
 
 const SAMPLE_LEFT = `function greet(name) {
   console.log("Hello, " + name);
@@ -17,6 +19,14 @@ const SAMPLE_RIGHT = `function greet(name, greeting) {
 }
 
 greet("world", "Hi");`;
+
+function loadState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch {}
+  return null;
+}
 
 function CombinedView({ edits }) {
   if (edits.length === 0) {
@@ -158,9 +168,14 @@ function SideBySideView({ edits }) {
 }
 
 function App() {
-  const [left, setLeft] = useState(SAMPLE_LEFT);
-  const [right, setRight] = useState(SAMPLE_RIGHT);
-  const [viewMode, setViewMode] = useState('combined');
+  const saved = loadState();
+  const [left, setLeft] = useState(saved?.left ?? SAMPLE_LEFT);
+  const [right, setRight] = useState(saved?.right ?? SAMPLE_RIGHT);
+  const [viewMode, setViewMode] = useState(saved?.viewMode ?? 'combined');
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ left, right, viewMode }));
+  }, [left, right, viewMode]);
 
   const edits = useMemo(() => computeDiff(left, right), [left, right]);
 
@@ -175,7 +190,13 @@ function App() {
 
   return (
     <div className="max-w-7xl mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">Diff Comparison</h1>
+      <a
+        href="../"
+        className="inline-flex items-center gap-1 text-sm text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+      >
+        ← Home
+      </a>
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6 mt-2">Diff Comparison</h1>
 
       <div className="flex flex-col md:flex-row gap-4 mb-6">
         <div className="flex-1 flex flex-col">

--- a/src/pages/diff-comparison/_app/diff.js
+++ b/src/pages/diff-comparison/_app/diff.js
@@ -1,0 +1,78 @@
+// Myers diff algorithm operating on lines
+export function computeDiff(oldText, newText) {
+  const oldLines = oldText.split('\n');
+  const newLines = newText.split('\n');
+  const n = oldLines.length;
+  const m = newLines.length;
+  const max = n + m;
+
+  if (max === 0) return [];
+
+  // Myers' algorithm
+  const v = new Array(2 * max + 1);
+  v[max + 1] = 0;
+  const trace = [];
+
+  for (let d = 0; d <= max; d++) {
+    trace.push([...v]);
+    for (let k = -d; k <= d; k += 2) {
+      const idx = k + max;
+      let x;
+      if (k === -d || (k !== d && v[idx - 1] < v[idx + 1])) {
+        x = v[idx + 1];
+      } else {
+        x = v[idx - 1] + 1;
+      }
+      let y = x - k;
+      while (x < n && y < m && oldLines[x] === newLines[y]) {
+        x++;
+        y++;
+      }
+      v[idx] = x;
+      if (x >= n && y >= m) {
+        return backtrack(trace, oldLines, newLines, max);
+      }
+    }
+  }
+  return [];
+}
+
+function backtrack(trace, oldLines, newLines, max) {
+  let x = oldLines.length;
+  let y = newLines.length;
+  const edits = [];
+
+  for (let d = trace.length - 1; d >= 0; d--) {
+    const v = trace[d];
+    const k = x - y;
+    const idx = k + max;
+    let prevK;
+    if (k === -d || (k !== d && v[idx - 1] < v[idx + 1])) {
+      prevK = k + 1;
+    } else {
+      prevK = k - 1;
+    }
+    const prevX = v[prevK + max];
+    const prevY = prevX - prevK;
+
+    // Diagonal moves (equal lines)
+    while (x > prevX && y > prevY) {
+      x--;
+      y--;
+      edits.unshift({ type: 'equal', oldLine: x, newLine: y, value: oldLines[x] });
+    }
+
+    if (d > 0) {
+      if (x === prevX) {
+        // Insert
+        y--;
+        edits.unshift({ type: 'insert', newLine: y, value: newLines[y] });
+      } else {
+        // Delete
+        x--;
+        edits.unshift({ type: 'delete', oldLine: x, value: oldLines[x] });
+      }
+    }
+  }
+  return edits;
+}

--- a/src/pages/diff-comparison/index.astro
+++ b/src/pages/diff-comparison/index.astro
@@ -1,0 +1,16 @@
+---
+// Full-page SPA — no Astro layout
+---
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Diff Comparison</title>
+</head>
+<body class="bg-gray-50 dark:bg-gray-900 min-h-screen">
+  <div id="app"></div>
+  <script>
+    import './_app/app.jsx';
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds a new interactive diff comparison tool at `/diff-comparison/`
- Two side-by-side text inputs with live diff generation as you type
- Supports **Combined** view (unified diff with +/- prefixes) and **Side by Side** view (split pane)
- Includes line numbers, color-coded additions/deletions, and change stats
- Uses Myers diff algorithm for accurate line-level comparison

## Test plan

- [ ] Visit `/diff-comparison/` and verify the sample diff renders correctly
- [ ] Edit both text areas and confirm the diff updates live
- [ ] Toggle between Combined and Side by Side views
- [ ] Test with empty inputs, identical inputs, and completely different inputs
- [ ] Verify dark mode styling works correctly

https://claude.ai/code/session_01LFVBWQQCy6VnN6iADugVu2