### PR TITLE
Add tri-state light/dark/auto theme toggle across notes and SPAs

### DIFF
--- a/scripts/new-tool.js
+++ b/scripts/new-tool.js
@@ -34,6 +34,7 @@ import AppLayout from '../../layouts/AppLayout.astro';
 // app.jsx
 writeFileSync(join(appDir, 'app.jsx'), `import { createRoot } from 'react-dom/client';
 import { useLocalStorage } from '../../../lib/useLocalStorage.js';
+import { ThemeToggle } from '../../../components/ThemeToggle.jsx';
 
 const PREFIX = '${slug}_';
 
@@ -51,6 +52,7 @@ export function App({ historyUrl }) {
             history
           </a>
         )}
+        <ThemeToggle className="ml-auto" />
       </nav>
       <h1 className="text-xl font-semibold">${title}</h1>
       {/* Replace this placeholder with your app */}

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,7 +1,9 @@
 ---
+import ThemeToggle from './ThemeToggle.astro';
 const base = import.meta.env.BASE_URL;
 ---
 
-<header class="mt-4 mb-8">
+<header class="mt-4 mb-8 flex items-center justify-between gap-4">
   <a href={base} class="text-xl font-bold text-heading no-underline hover:no-underline">{`By the Rocks`}</a>
+  <ThemeToggle />
 </header>

--- a/src/components/ThemeInit.astro
+++ b/src/components/ThemeInit.astro
@@ -1,0 +1,27 @@
+---
+// Runs before paint to set data-theme on <html>, preventing FOUC.
+// Shared by Layout.astro (notes) and AppLayout.astro (SPAs) so a single
+// localStorage pref drives both surfaces.
+---
+<script is:inline>
+  (() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const resolve = (pref) =>
+      pref === 'light' || pref === 'dark' ? pref : (mq.matches ? 'dark' : 'light');
+    const apply = (pref) => {
+      const root = document.documentElement;
+      root.dataset.themePref = pref;
+      root.dataset.theme = resolve(pref);
+    };
+    const read = () => {
+      try { return localStorage.getItem('theme') ?? 'auto'; } catch { return 'auto'; }
+    };
+    apply(read());
+    mq.addEventListener('change', () => { if (read() === 'auto') apply('auto'); });
+    window.addEventListener('storage', (e) => { if (e.key === 'theme') apply(read()); });
+    window.__setTheme = (pref) => {
+      try { localStorage.setItem('theme', pref); } catch {}
+      apply(pref);
+    };
+  })();
+</script>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,65 +1,47 @@
 ---
-// Tri-state theme toggle: light / auto / dark.
-// Reads/writes via window.__setTheme defined by ThemeInit.
+// Single-button tri-state toggle: cycles auto → light → dark → auto.
+// Icon reflects the current preference.
 ---
-<fieldset
-  class="theme-toggle inline-flex items-center gap-0 rounded-full border border-border p-0.5 text-sm"
-  aria-label="Theme"
+<button
+  type="button"
+  class="theme-toggle inline-flex items-center justify-center w-8 h-8 rounded-full text-text opacity-60 hover:opacity-100 cursor-pointer"
+  aria-label="Theme: auto"
+  title="Theme: auto"
 >
-  <legend class="sr-only">Theme</legend>
-  <button type="button" data-theme-value="light" aria-label="Light theme" title="Light">
-    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-      <circle cx="12" cy="12" r="4"/>
-      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
-    </svg>
-  </button>
-  <button type="button" data-theme-value="auto" aria-label="System theme" title="Auto">
-    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-      <rect x="3" y="4" width="18" height="13" rx="2"/>
-      <path d="M8 21h8M12 17v4"/>
-    </svg>
-  </button>
-  <button type="button" data-theme-value="dark" aria-label="Dark theme" title="Dark">
-    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-      <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/>
-    </svg>
-  </button>
-</fieldset>
-
-<style>
-  .theme-toggle button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 1.75rem;
-    height: 1.75rem;
-    border-radius: 9999px;
-    color: var(--text);
-    opacity: 0.6;
-    background: transparent;
-    cursor: pointer;
-  }
-  .theme-toggle button:hover { opacity: 1; }
-  .theme-toggle button[aria-pressed="true"] {
-    opacity: 1;
-    background: var(--code-bg);
-    color: var(--heading);
-  }
-</style>
+  <svg class="icon-auto" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <rect x="3" y="4" width="18" height="13" rx="2"/>
+    <path d="M8 21h8M12 17v4"/>
+  </svg>
+  <svg class="icon-light hidden" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="4"/>
+    <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
+  </svg>
+  <svg class="icon-dark hidden" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/>
+  </svg>
+</button>
 
 <script>
-  const buttons = document.querySelectorAll<HTMLButtonElement>('.theme-toggle button[data-theme-value]');
-  const sync = () => {
-    const pref = document.documentElement.dataset.themePref ?? 'auto';
-    buttons.forEach((b) => {
-      b.setAttribute('aria-pressed', String(b.dataset.themeValue === pref));
-    });
+  const order = ['auto', 'light', 'dark'] as const;
+  type Pref = typeof order[number];
+  const btn = document.querySelector<HTMLButtonElement>('.theme-toggle')!;
+  const icons: Record<Pref, HTMLElement | null> = {
+    auto: btn.querySelector('.icon-auto'),
+    light: btn.querySelector('.icon-light'),
+    dark: btn.querySelector('.icon-dark'),
   };
-  buttons.forEach((b) => {
-    b.addEventListener('click', () => {
-      (window as any).__setTheme?.(b.dataset.themeValue);
-      sync();
-    });
+  const sync = () => {
+    const pref = (document.documentElement.dataset.themePref as Pref) ?? 'auto';
+    for (const k of order) icons[k]?.classList.toggle('hidden', k !== pref);
+    const label = `Theme: ${pref}`;
+    btn.setAttribute('aria-label', label);
+    btn.setAttribute('title', label);
+  };
+  btn.addEventListener('click', () => {
+    const current = (document.documentElement.dataset.themePref as Pref) ?? 'auto';
+    const next = order[(order.indexOf(current) + 1) % order.length];
+    (window as any).__setTheme?.(next);
+    sync();
   });
   sync();
 </script>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,10 +1,11 @@
 ---
 // Single-button tri-state toggle: cycles auto → light → dark → auto.
-// Icon reflects the current preference.
+// Icon reflects the current preference. Pass `class` to position it.
+const { class: className = '' } = Astro.props;
 ---
 <button
   type="button"
-  class="theme-toggle inline-flex items-center justify-center w-8 h-8 rounded-full text-text opacity-60 hover:opacity-100 cursor-pointer"
+  class:list={['theme-toggle inline-flex items-center justify-center w-8 h-8 rounded-full text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100 cursor-pointer', className]}
   aria-label="Theme: auto"
   title="Theme: auto"
 >

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,0 +1,65 @@
+---
+// Tri-state theme toggle: light / auto / dark.
+// Reads/writes via window.__setTheme defined by ThemeInit.
+---
+<fieldset
+  class="theme-toggle inline-flex items-center gap-0 rounded-full border border-border p-0.5 text-sm"
+  aria-label="Theme"
+>
+  <legend class="sr-only">Theme</legend>
+  <button type="button" data-theme-value="light" aria-label="Light theme" title="Light">
+    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="4"/>
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
+    </svg>
+  </button>
+  <button type="button" data-theme-value="auto" aria-label="System theme" title="Auto">
+    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <rect x="3" y="4" width="18" height="13" rx="2"/>
+      <path d="M8 21h8M12 17v4"/>
+    </svg>
+  </button>
+  <button type="button" data-theme-value="dark" aria-label="Dark theme" title="Dark">
+    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/>
+    </svg>
+  </button>
+</fieldset>
+
+<style>
+  .theme-toggle button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 9999px;
+    color: var(--text);
+    opacity: 0.6;
+    background: transparent;
+    cursor: pointer;
+  }
+  .theme-toggle button:hover { opacity: 1; }
+  .theme-toggle button[aria-pressed="true"] {
+    opacity: 1;
+    background: var(--code-bg);
+    color: var(--heading);
+  }
+</style>
+
+<script>
+  const buttons = document.querySelectorAll<HTMLButtonElement>('.theme-toggle button[data-theme-value]');
+  const sync = () => {
+    const pref = document.documentElement.dataset.themePref ?? 'auto';
+    buttons.forEach((b) => {
+      b.setAttribute('aria-pressed', String(b.dataset.themeValue === pref));
+    });
+  };
+  buttons.forEach((b) => {
+    b.addEventListener('click', () => {
+      (window as any).__setTheme?.(b.dataset.themeValue);
+      sync();
+    });
+  });
+  sync();
+</script>

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+
+const order = ['auto', 'light', 'dark'];
+
+const readPref = () =>
+  (typeof document !== 'undefined' && document.documentElement.dataset.themePref) || 'auto';
+
+export function ThemeToggle({ className = '' }) {
+  const [pref, setPref] = useState(readPref);
+
+  useEffect(() => {
+    const onStorage = (e) => { if (e.key === 'theme') setPref(readPref()); };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  const cycle = () => {
+    const next = order[(order.indexOf(pref) + 1) % order.length];
+    window.__setTheme?.(next);
+    setPref(next);
+  };
+
+  const label = `Theme: ${pref}`;
+  const iconProps = {
+    width: 16, height: 16, viewBox: '0 0 24 24',
+    fill: 'none', stroke: 'currentColor', strokeWidth: 2,
+    strokeLinecap: 'round', strokeLinejoin: 'round', 'aria-hidden': true,
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={cycle}
+      aria-label={label}
+      title={label}
+      className={`inline-flex items-center justify-center w-6 h-6 rounded hover:text-gray-600 dark:hover:text-gray-300 transition-colors cursor-pointer ${className}`}
+    >
+      {pref === 'auto' && (
+        <svg {...iconProps}>
+          <rect x="3" y="4" width="18" height="13" rx="2" />
+          <path d="M8 21h8M12 17v4" />
+        </svg>
+      )}
+      {pref === 'light' && (
+        <svg {...iconProps}>
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+        </svg>
+      )}
+      {pref === 'dark' && (
+        <svg {...iconProps}>
+          <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/src/layouts/AppLayout.astro
+++ b/src/layouts/AppLayout.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/app.css';
 import ThemeInit from '../components/ThemeInit.astro';
+import ThemeToggle from '../components/ThemeToggle.astro';
 import { historyFromPagePath } from '../lib/history.js';
 
 const { title } = Astro.props;
@@ -15,6 +16,7 @@ const historyUrl = historyFromPagePath(Astro.url.pathname);
   <slot name="head" />
 </head>
 <body class="bg-gray-50 dark:bg-gray-900 min-h-screen">
+  <ThemeToggle class="fixed top-2 right-2 z-50" />
   <div id="app" data-history-url={historyUrl}></div>
   <slot />
 </body>

--- a/src/layouts/AppLayout.astro
+++ b/src/layouts/AppLayout.astro
@@ -1,7 +1,6 @@
 ---
 import '../styles/app.css';
 import ThemeInit from '../components/ThemeInit.astro';
-import ThemeToggle from '../components/ThemeToggle.astro';
 import { historyFromPagePath } from '../lib/history.js';
 
 const { title } = Astro.props;
@@ -16,7 +15,6 @@ const historyUrl = historyFromPagePath(Astro.url.pathname);
   <slot name="head" />
 </head>
 <body class="bg-gray-50 dark:bg-gray-900 min-h-screen">
-  <ThemeToggle class="fixed top-2 right-2 z-50" />
   <div id="app" data-history-url={historyUrl}></div>
   <slot />
 </body>

--- a/src/layouts/AppLayout.astro
+++ b/src/layouts/AppLayout.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/app.css';
+import ThemeInit from '../components/ThemeInit.astro';
 import { historyFromPagePath } from '../lib/history.js';
 
 const { title } = Astro.props;
@@ -7,6 +8,7 @@ const historyUrl = historyFromPagePath(Astro.url.pathname);
 ---
 <html lang="en">
 <head>
+  <ThemeInit />
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{title}</title>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/global.css';
 import Header from '../components/Header.astro';
+import ThemeInit from '../components/ThemeInit.astro';
 
 interface Props {
   title?: string;
@@ -24,6 +25,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 <!DOCTYPE html>
 <html lang="en" class="font-sans text-base leading-relaxed text-text bg-bg">
 <head>
+  <ThemeInit />
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta http-equiv="X-Clacks-Overhead" content="GNU Terry Pratchett" />

--- a/src/pages/bridal-skincare/_app/app.jsx
+++ b/src/pages/bridal-skincare/_app/app.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
+import { ThemeToggle } from '../../../components/ThemeToggle.jsx';
 
 const DAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
@@ -467,6 +468,7 @@ function App({ historyUrl }) {
               history
             </a>
           )}
+          <ThemeToggle className="ml-auto" />
         </nav>
 
         <h1 className="text-2xl font-bold mt-4 mb-1">🌸 Bridal Skincare Routine</h1>

--- a/src/pages/chat/_app/app.jsx
+++ b/src/pages/chat/_app/app.jsx
@@ -1,6 +1,7 @@
 import { createRoot } from 'react-dom/client';
 import { useEffect, useRef, useState } from 'react';
 import { useLocalStorage } from '../../../lib/useLocalStorage.js';
+import { ThemeToggle } from '../../../components/ThemeToggle.jsx';
 
 const PREFIX = 'chat_';
 
@@ -47,13 +48,16 @@ export function App({ historyUrl }) {
           )}
         </nav>
         <h1 className="text-base font-semibold">Chat</h1>
-        <button
-          onClick={clear}
-          disabled={messages.length === 0}
-          className="text-sm text-gray-400 hover:text-red-500 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-        >
-          Clear
-        </button>
+        <div className="flex items-center gap-3">
+          <ThemeToggle className="text-gray-400" />
+          <button
+            onClick={clear}
+            disabled={messages.length === 0}
+            className="text-sm text-gray-400 hover:text-red-500 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            Clear
+          </button>
+        </div>
       </header>
 
       <div ref={listRef} className="flex-1 overflow-y-auto px-4 py-4">

--- a/src/pages/image-compare/_app/app.jsx
+++ b/src/pages/image-compare/_app/app.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
+import { ThemeToggle } from '../../../components/ThemeToggle.jsx';
 
 const MAX_DIM = 2000;
 const QUALITY = 0.85;
@@ -153,6 +154,7 @@ function UploadScreen({ image1, image2, onImage, onSwap, onCompare }) {
               history
             </a>
           )}
+          <ThemeToggle className="ml-auto" />
         </nav>
 
         <h1 className="text-2xl font-bold mt-4 mb-6">Image Compare</h1>

--- a/src/pages/image-compress/_app/app.jsx
+++ b/src/pages/image-compress/_app/app.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { createRoot } from 'react-dom/client';
+import { ThemeToggle } from '../../../components/ThemeToggle.jsx';
 
 const MAX_DIM_DEFAULT = 2000;
 const QUALITY_DEFAULT = 85;
@@ -102,6 +103,7 @@ function App({ historyUrl }) {
               history
             </a>
           )}
+          <ThemeToggle className="ml-auto" />
         </nav>
 
         <h1 className="text-2xl font-bold mt-4 mb-6">Image Compress</h1>

--- a/src/pages/markdown-preview/_app/app.jsx
+++ b/src/pages/markdown-preview/_app/app.jsx
@@ -4,6 +4,7 @@ import { marked } from 'marked';
 import mermaid from 'mermaid';
 import DOMPurify from 'dompurify';
 import { useLocalStorage } from '../../../lib/useLocalStorage.js';
+import { ThemeToggle } from '../../../components/ThemeToggle.jsx';
 import './typography.css';
 
 marked.use({
@@ -57,6 +58,7 @@ function App({ historyUrl }) {
               history
             </a>
           )}
+          <ThemeToggle className="ml-auto" />
         </nav>
         <textarea
           className="flex-1 w-full resize-none rounded-lg p-4 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-gray-50 dark:bg-gray-800 dark:text-gray-100 border border-gray-200 dark:border-gray-700"

--- a/src/pages/recommender/_app/components/ListsView.jsx
+++ b/src/pages/recommender/_app/components/ListsView.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { getPhase, getPhaseLabel, getPendingCount, getReviewedCount } from '../utils.js';
+import { ThemeToggle } from '../../../../components/ThemeToggle.jsx';
 
 const PHASE_COLORS = {
   exploring: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
@@ -118,6 +119,7 @@ export const ListsView = ({ lists, onSelectList, onCreateList, onChangeApiKey, o
               history
             </a>
           )}
+          <ThemeToggle className="ml-auto" />
         </nav>
 
         <div className="flex items-center justify-between mb-6">

--- a/src/pages/sorting-comparator/_app/app.jsx
+++ b/src/pages/sorting-comparator/_app/app.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import { createRoot } from 'react-dom/client';
 import ALGORITHMS from './algorithms/index.js';
+import { ThemeToggle } from '../../../components/ThemeToggle.jsx';
 
 function shuffle(arr) {
   const a = [...arr];
@@ -582,6 +583,7 @@ const App = ({ historyUrl }) => {
                 history
               </a>
             )}
+            <ThemeToggle className="ml-auto" />
           </nav>
         )}
 

--- a/src/pages/transit-converter/_app/app.jsx
+++ b/src/pages/transit-converter/_app/app.jsx
@@ -1,6 +1,7 @@
 import { createRoot } from 'react-dom/client';
 import { useState } from 'react';
 import transit from 'transit-js';
+import { ThemeToggle } from '../../../components/ThemeToggle.jsx';
 
 const reader = transit.reader('json');
 
@@ -59,6 +60,7 @@ function App({ historyUrl }) {
             history
           </a>
         )}
+        <ThemeToggle className="ml-auto" />
       </nav>
 
       <h1 className="text-xl font-semibold">Transit → JSON</h1>

--- a/src/pages/ynab-reimbursement/_app/app.jsx
+++ b/src/pages/ynab-reimbursement/_app/app.jsx
@@ -8,6 +8,7 @@ import { TokenInputView } from './components/TokenInputView.jsx';
 import { BudgetSelectionView } from './components/BudgetSelectionView.jsx';
 import { ConfigMenu } from './components/ConfigMenu.jsx';
 import { MainView } from './components/MainView.jsx';
+import { ThemeToggle } from '../../../components/ThemeToggle.jsx';
 
 const CONFIG_PREFIX = 'ynabReimbursement_';
 
@@ -268,6 +269,7 @@ const App = ({ historyUrl }) => {
             history
           </a>
         )}
+        <ThemeToggle className="ml-auto" />
       </nav>
 
       {isLoading && (

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,1 +1,2 @@
 @import "tailwindcss";
+@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
+@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
 @theme {
   --color-border: var(--border);
@@ -25,17 +26,15 @@
   --border: #ddd;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #01242e;
-    --text: #ddd;
-    --heading: #eee;
-    --link: #8cc2dd;
-    --link-visited: #8b6fcb;
-    --code-bg: #000;
-    --code-text: #ddd;
-    --border: #444;
-  }
+[data-theme="dark"] {
+  --bg: #01242e;
+  --text: #ddd;
+  --heading: #eee;
+  --link: #8cc2dd;
+  --link-visited: #8b6fcb;
+  --code-bg: #000;
+  --code-text: #ddd;
+  --border: #444;
 }
 
 /* Map theme colours to prose — these are variable assignments, not element styles */


### PR DESCRIPTION
Drives both surfaces off a single data-theme attribute on <html>, set by
a shared inline script before paint. Redefines Tailwind v4's dark: variant
to key on the attribute so existing dark: classes in SPAs follow the toggle
without per-app edits.

https://claude.ai/code/session_014QCmRyUBEkQ5gu1XF6y5Cg