### PR TITLE
Make exercise sessions explicit with Start/Cancel and duration

### DIFF
--- a/src/pages/exercise/_app/app.test.jsx
+++ b/src/pages/exercise/_app/app.test.jsx
@@ -20,31 +20,63 @@ describe('Exercise app', () => {
     expect(home.getAttribute('href')).toBe('../');
   });
 
-  test('toggling a set persists to localStorage', () => {
+  test('sets are inert until the user starts a session', () => {
     render(<App />);
-    // Find any "Set 1" button (rest days won't have one — Wed/Sun)
+    const startBtn = screen.queryByRole('button', { name: /^start (workout|.*'s workout)/i });
+    if (!startBtn) return; // rest day, skip
+    // Sets exist but clicking does nothing while no session is running.
     const set1 = screen.queryAllByRole('button', { name: /set 1|done/i })[0];
-    if (!set1) return; // rest day, skip
-    expect(set1.getAttribute('aria-pressed')).toBe('false');
-    fireEvent.click(set1);
-    expect(set1.getAttribute('aria-pressed')).toBe('true');
+    if (set1) {
+      fireEvent.click(set1);
+      const beforeStart = JSON.parse(localStorage.getItem('exercise_state') || '{}');
+      expect(beforeStart.inProgress ?? null).toBeNull();
+    }
+    fireEvent.click(startBtn);
     const stored = JSON.parse(localStorage.getItem('exercise_state'));
     expect(stored.inProgress).not.toBeNull();
-    expect(stored.inProgress.completedSets).toBeTruthy();
+    expect(stored.inProgress.startedAt).toBeTypeOf('number');
+    // After starting, toggling a set should record it.
+    const setNow = screen.queryAllByRole('button', { name: /set 1|done/i })[0];
+    if (setNow) {
+      fireEvent.click(setNow);
+      const after = JSON.parse(localStorage.getItem('exercise_state'));
+      expect(after.inProgress.completedSets).toBeTruthy();
+    }
   });
 
   test('finishing an empty workout warns and does nothing', () => {
     const original = window.confirm;
     window.confirm = vi.fn(() => false);
     render(<App />);
-    const finish = screen.queryByRole('button', { name: /finish workout/i });
-    if (!finish) {
+    const startBtn = screen.queryByRole('button', { name: /^start (workout|.*'s workout)/i });
+    if (!startBtn) {
       window.confirm = original;
-      return;
+      return; // rest day
     }
+    fireEvent.click(startBtn);
+    const finish = screen.getByRole('button', { name: /finish workout/i });
     fireEvent.click(finish);
     expect(window.confirm).toHaveBeenCalled();
     const stored = JSON.parse(localStorage.getItem('exercise_state') || '{}');
+    expect(stored.history?.length ?? 0).toBe(0);
+    window.confirm = original;
+  });
+
+  test('cancel button discards an in-progress session after confirmation', () => {
+    const original = window.confirm;
+    window.confirm = vi.fn(() => true);
+    render(<App />);
+    const startBtn = screen.queryByRole('button', { name: /^start (workout|.*'s workout)/i });
+    if (!startBtn) {
+      window.confirm = original;
+      return;
+    }
+    fireEvent.click(startBtn);
+    const cancel = screen.getByRole('button', { name: /^cancel$/i });
+    fireEvent.click(cancel);
+    expect(window.confirm).toHaveBeenCalled();
+    const stored = JSON.parse(localStorage.getItem('exercise_state'));
+    expect(stored.inProgress).toBeNull();
     expect(stored.history?.length ?? 0).toBe(0);
     window.confirm = original;
   });

--- a/src/pages/exercise/_app/screens/History.jsx
+++ b/src/pages/exercise/_app/screens/History.jsx
@@ -47,11 +47,9 @@ export function History({ state, navigate }) {
                         {done}/{total}
                       </p>
                     </div>
-                    {entry.focus && (
-                      <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 truncate">
-                        {entry.focus}
-                      </p>
-                    )}
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 truncate">
+                      {[entry.focus, formatDuration(entry)].filter(Boolean).join(' · ')}
+                    </p>
                   </button>
                 </li>
               );
@@ -67,6 +65,18 @@ function prettyDate(iso) {
   // iso like "2026-04-28"
   const d = new Date(iso + 'T12:00:00');
   return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short' });
+}
+
+// Compact duration label, e.g. "12m" or "1h 05m". Returns "" for entries
+// logged before timestamps were tracked so the caller can omit the segment.
+function formatDuration(entry) {
+  if (!entry.startedAt || !entry.finishedAt) return '';
+  const totalMin = Math.round((entry.finishedAt - entry.startedAt) / 60000);
+  if (totalMin < 1) return '<1m';
+  if (totalMin < 60) return `${totalMin}m`;
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  return `${h}h ${String(m).padStart(2, '0')}m`;
 }
 
 // Group history entries into weeks (Monday-start). Returns [[label, entries[]], ...].

--- a/src/pages/exercise/_app/screens/HistoryDetail.jsx
+++ b/src/pages/exercise/_app/screens/HistoryDetail.jsx
@@ -41,7 +41,7 @@ export function HistoryDetail({ state, entryId, navigate }) {
       <header className="mb-4 text-center">
         <p className="text-sm text-gray-500 dark:text-gray-400">{entry.focus}</p>
         <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
-          {prettyDate(entry.date)} · {done}/{total} done
+          {[prettyDate(entry.date), `${done}/${total} done`, formatDuration(entry)].filter(Boolean).join(' · ')}
         </p>
       </header>
 
@@ -77,4 +77,14 @@ export function HistoryDetail({ state, entryId, navigate }) {
 function prettyDate(iso) {
   const d = new Date(iso + 'T12:00:00');
   return d.toLocaleDateString(undefined, { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' });
+}
+
+function formatDuration(entry) {
+  if (!entry.startedAt || !entry.finishedAt) return '';
+  const totalMin = Math.round((entry.finishedAt - entry.startedAt) / 60000);
+  if (totalMin < 1) return '<1m';
+  if (totalMin < 60) return `${totalMin}m`;
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  return `${h}h ${String(m).padStart(2, '0')}m`;
 }

--- a/src/pages/exercise/_app/screens/Today.jsx
+++ b/src/pages/exercise/_app/screens/Today.jsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   DAY_NAMES,
-  toggleSet, finishWorkout, resetWorkout,
+  toggleSet, startWorkout, finishWorkout, cancelWorkout,
   totalUnits, completedUnits,
   toggleCircuitChild, completeCircuitRound,
   updateItem, removeItem, swapExercise,
@@ -25,8 +25,7 @@ export function Today({ state, setState, today }) {
 
   const inProgressDay = state.inProgress?.day ?? null;
   const isViewingActive = inProgressDay === viewDay;
-  const noActive = inProgressDay === null;
-  const interactive = !day.rest && (isViewingActive || noActive);
+  const interactive = !day.rest && isViewingActive;
   const completed = isViewingActive ? state.inProgress.completedSets : {};
   const circuitProgress = isViewingActive ? (state.inProgress.circuitProgress ?? {}) : {};
 
@@ -39,14 +38,19 @@ export function Today({ state, setState, today }) {
   const handleToggle = (itemId, index) =>
     setState(s => toggleSet(s, viewDay, itemId, index));
 
+  const handleStart = () => {
+    primeAudio();
+    setState(s => startWorkout(s, viewDay));
+  };
+
   const handleFinish = () => {
     if (done === 0 && !confirm('Finish workout with nothing checked off?')) return;
     setState(finishWorkout);
   };
 
-  const handleReset = () => {
-    if (!confirm('Clear all checkmarks for this workout?')) return;
-    setState(resetWorkout);
+  const handleCancel = () => {
+    if (!confirm('Cancel this workout? It won’t be added to your history.')) return;
+    setState(cancelWorkout);
   };
 
   const findItem = id => {
@@ -90,8 +94,16 @@ export function Today({ state, setState, today }) {
         <ActiveBanner
           activeDay={inProgressDay}
           onResume={() => setViewDay(inProgressDay)}
-          onDiscard={() => setState(resetWorkout)}
+          onDiscard={() => setState(cancelWorkout)}
         />
+      )}
+
+      {!day.rest && !inProgressDay && (
+        <StartBanner viewDay={viewDay} today={today} onStart={handleStart} />
+      )}
+
+      {isViewingActive && (
+        <SessionBanner startedAt={state.inProgress.startedAt} onCancel={handleCancel} />
       )}
 
       {day.rest ? (
@@ -132,7 +144,7 @@ export function Today({ state, setState, today }) {
           </ul>
 
           {interactive && (
-            <div className="mt-8 flex flex-col gap-3">
+            <div className="mt-8">
               <button
                 type="button"
                 onClick={handleFinish}
@@ -140,15 +152,6 @@ export function Today({ state, setState, today }) {
               >
                 Finish workout
               </button>
-              {isViewingActive && done > 0 && (
-                <button
-                  type="button"
-                  onClick={handleReset}
-                  className="text-sm text-gray-500 dark:text-gray-400 underline-offset-2 hover:underline"
-                >
-                  Clear checkmarks
-                </button>
-              )}
             </div>
           )}
         </>
@@ -202,6 +205,60 @@ function ActiveBanner({ activeDay, onResume, onDiscard }) {
       </div>
     </div>
   );
+}
+
+function StartBanner({ viewDay, today, onStart }) {
+  const label = viewDay === today ? 'Start workout' : `Start ${DAY_NAMES[viewDay]}'s workout`;
+  return (
+    <div className="mb-4">
+      <button
+        type="button"
+        onClick={onStart}
+        className="w-full py-3 rounded-md bg-emerald-600 hover:bg-emerald-500 text-white font-semibold transition-colors"
+      >
+        {label}
+      </button>
+      <p className="mt-2 text-xs text-gray-500 dark:text-gray-400 text-center">
+        Sets unlock once a session is running.
+      </p>
+    </div>
+  );
+}
+
+function SessionBanner({ startedAt, onCancel }) {
+  const seconds = useElapsedSeconds(startedAt);
+  return (
+    <div className="rounded-lg border border-emerald-300/60 bg-emerald-50 dark:bg-emerald-500/10 dark:border-emerald-500/30 p-3 mb-4 flex items-center justify-between gap-3">
+      <div className="text-sm text-emerald-900 dark:text-emerald-200">
+        <span className="font-medium">Session in progress</span>
+        <span className="ml-2 tabular-nums">{formatElapsed(seconds)}</span>
+      </div>
+      <button
+        type="button"
+        onClick={onCancel}
+        className="text-sm underline text-emerald-900 dark:text-emerald-200 underline-offset-2 hover:no-underline"
+      >
+        Cancel
+      </button>
+    </div>
+  );
+}
+
+function useElapsedSeconds(startedAt) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  return Math.max(0, Math.floor((now - startedAt) / 1000));
+}
+
+function formatElapsed(totalSec) {
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  const pad = n => String(n).padStart(2, '0');
+  return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
 }
 
 function RestDay() {

--- a/src/pages/exercise/_app/store.js
+++ b/src/pages/exercise/_app/store.js
@@ -65,9 +65,16 @@ export const completedUnits = (day, completedSets) =>
 
 // ── State transformations (pure) ─────────────────────────────────────
 
-// Ensure inProgress exists for the given day. Returns updated state.
-const ensureInProgress = (state, dayKey) => {
-  if (state.inProgress && state.inProgress.day === dayKey) return state;
+// Returns the active in-progress session if it matches `dayKey`, else null.
+// Returning null tells callers to no-op: set toggling is gated on the user
+// having pressed "Start workout" first.
+const activeFor = (state, dayKey) =>
+  state.inProgress && state.inProgress.day === dayKey ? state.inProgress : null;
+
+// Begin a session for `dayKey`. No-op if a session is already in progress
+// (the UI surfaces a banner offering to resume or discard the existing one).
+export const startWorkout = (state, dayKey) => {
+  if (state.inProgress) return state;
   return {
     ...state,
     inProgress: {
@@ -79,22 +86,25 @@ const ensureInProgress = (state, dayKey) => {
   };
 };
 
+// Discard the in-progress session without writing to history.
+export const cancelWorkout = state => ({ ...state, inProgress: null });
+
 export const toggleSet = (state, dayKey, itemId, index) => {
-  const next = ensureInProgress(state, dayKey);
-  const day = next.template.days[dayKey];
+  if (!activeFor(state, dayKey)) return state;
+  const day = state.template.days[dayKey];
   const item = findItem(day, itemId);
   if (!item) return state;
   const max = unitCount(item);
-  const arr = next.inProgress.completedSets[itemId]
-    ? [...next.inProgress.completedSets[itemId]]
+  const arr = state.inProgress.completedSets[itemId]
+    ? [...state.inProgress.completedSets[itemId]]
     : Array(max).fill(false);
   arr[index] = !arr[index];
   return {
-    ...next,
+    ...state,
     inProgress: {
-      ...next.inProgress,
+      ...state.inProgress,
       completedSets: {
-        ...next.inProgress.completedSets,
+        ...state.inProgress.completedSets,
         [itemId]: arr,
       },
     },
@@ -200,9 +210,15 @@ export const finishWorkout = state => {
   if (!state.inProgress) return state;
   const dayKey = state.inProgress.day;
   const day = state.template.days[dayKey];
+  const startedAt = state.inProgress.startedAt;
+  const finishedAt = Date.now();
   const entry = {
-    id: `h_${Date.now()}`,
-    date: new Date().toISOString().slice(0, 10),
+    id: `h_${finishedAt}`,
+    // Date follows session start, so a session that crosses midnight is
+    // still attributed to the day it began on.
+    date: new Date(startedAt).toISOString().slice(0, 10),
+    startedAt,
+    finishedAt,
     day: dayKey,
     focus: day.focus,
     snapshot: day,
@@ -215,7 +231,9 @@ export const finishWorkout = state => {
   };
 };
 
-export const resetWorkout = state => ({ ...state, inProgress: null });
+// Kept as an alias for code paths (e.g. importing a routine) that need to
+// drop any active session without going through the user-facing cancel flow.
+export const resetWorkout = cancelWorkout;
 
 // ── Circuit per-child progress ───────────────────────────────────────
 // Circuits track two things during a workout:
@@ -225,21 +243,21 @@ export const resetWorkout = state => ({ ...state, inProgress: null });
 // "Complete round" advances completedSets and resets circuitProgress.
 
 export const toggleCircuitChild = (state, dayKey, circuitId, childIndex) => {
-  const next = ensureInProgress(state, dayKey);
-  const day = next.template.days[dayKey];
+  if (!activeFor(state, dayKey)) return state;
+  const day = state.template.days[dayKey];
   const circuit = findItem(day, circuitId);
   if (!circuit || circuit.kind !== 'circuit') return state;
   const len = circuit.children.length;
-  const arr = next.inProgress.circuitProgress?.[circuitId]
-    ? [...next.inProgress.circuitProgress[circuitId]]
+  const arr = state.inProgress.circuitProgress?.[circuitId]
+    ? [...state.inProgress.circuitProgress[circuitId]]
     : Array(len).fill(false);
   arr[childIndex] = !arr[childIndex];
   return {
-    ...next,
+    ...state,
     inProgress: {
-      ...next.inProgress,
+      ...state.inProgress,
       circuitProgress: {
-        ...(next.inProgress.circuitProgress ?? {}),
+        ...(state.inProgress.circuitProgress ?? {}),
         [circuitId]: arr,
       },
     },
@@ -247,23 +265,23 @@ export const toggleCircuitChild = (state, dayKey, circuitId, childIndex) => {
 };
 
 export const completeCircuitRound = (state, dayKey, circuitId) => {
-  const next = ensureInProgress(state, dayKey);
-  const day = next.template.days[dayKey];
+  if (!activeFor(state, dayKey)) return state;
+  const day = state.template.days[dayKey];
   const circuit = findItem(day, circuitId);
   if (!circuit || circuit.kind !== 'circuit') return state;
   // Tick the next unticked round.
-  const rounds = next.inProgress.completedSets[circuitId]
-    ? [...next.inProgress.completedSets[circuitId]]
+  const rounds = state.inProgress.completedSets[circuitId]
+    ? [...state.inProgress.completedSets[circuitId]]
     : Array(circuit.rounds).fill(false);
   const idx = rounds.indexOf(false);
   if (idx === -1) return state; // already complete
   rounds[idx] = true;
   return {
-    ...next,
+    ...state,
     inProgress: {
-      ...next.inProgress,
-      completedSets: { ...next.inProgress.completedSets, [circuitId]: rounds },
-      circuitProgress: { ...(next.inProgress.circuitProgress ?? {}), [circuitId]: Array(circuit.children.length).fill(false) },
+      ...state.inProgress,
+      completedSets: { ...state.inProgress.completedSets, [circuitId]: rounds },
+      circuitProgress: { ...(state.inProgress.circuitProgress ?? {}), [circuitId]: Array(circuit.children.length).fill(false) },
     },
   };
 };

--- a/src/pages/exercise/_app/store.test.js
+++ b/src/pages/exercise/_app/store.test.js
@@ -1,8 +1,9 @@
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, vi, afterEach } from 'vitest';
 import {
   parseImportedRoutine, applyImportedRoutine, DAYS,
   toggleCircuitChild, completeCircuitRound,
   addCircuit, addCircuitChild,
+  startWorkout, cancelWorkout, finishWorkout, toggleSet,
 } from './store.js';
 import { seedPool, seedTemplate } from './seed.js';
 
@@ -266,9 +267,10 @@ describe('parseImportedRoutine — item validation', () => {
 describe('circuit progress', () => {
   // Find the Mon circuit in seed (Elliptical Intervals).
   const monCircuit = baseState.template.days.mon.items.find(i => i.kind === 'circuit');
+  const startedMon = () => startWorkout(baseState, 'mon');
 
   test('toggleCircuitChild flips per-child state for the current round', () => {
-    const s1 = toggleCircuitChild(baseState, 'mon', monCircuit.id, 0);
+    const s1 = toggleCircuitChild(startedMon(), 'mon', monCircuit.id, 0);
     expect(s1.inProgress.circuitProgress[monCircuit.id][0]).toBe(true);
     expect(s1.inProgress.circuitProgress[monCircuit.id][1]).toBe(false);
     const s2 = toggleCircuitChild(s1, 'mon', monCircuit.id, 0);
@@ -276,7 +278,7 @@ describe('circuit progress', () => {
   });
 
   test('completeCircuitRound ticks next round and resets children', () => {
-    let s = toggleCircuitChild(baseState, 'mon', monCircuit.id, 0);
+    let s = toggleCircuitChild(startedMon(), 'mon', monCircuit.id, 0);
     s = toggleCircuitChild(s, 'mon', monCircuit.id, 1);
     s = completeCircuitRound(s, 'mon', monCircuit.id);
     expect(s.inProgress.completedSets[monCircuit.id][0]).toBe(true);
@@ -284,13 +286,67 @@ describe('circuit progress', () => {
   });
 
   test('completeCircuitRound is a no-op once all rounds are done', () => {
-    let s = baseState;
+    let s = startedMon();
     for (let i = 0; i < monCircuit.rounds; i++) {
       s = completeCircuitRound(s, 'mon', monCircuit.id);
     }
     const before = s.inProgress.completedSets[monCircuit.id].slice();
     s = completeCircuitRound(s, 'mon', monCircuit.id);
     expect(s.inProgress.completedSets[monCircuit.id]).toEqual(before);
+  });
+
+  test('toggleCircuitChild is a no-op without an active session', () => {
+    const s = toggleCircuitChild(baseState, 'mon', monCircuit.id, 0);
+    expect(s).toBe(baseState);
+  });
+});
+
+describe('session lifecycle', () => {
+  afterEach(() => vi.useRealTimers());
+
+  test('toggleSet does nothing until startWorkout is called', () => {
+    // Pick the first reps/timed item on Monday.
+    const item = baseState.template.days.mon.items.find(i => i.kind === 'reps-exercise' || i.kind === 'timed-exercise');
+    const before = toggleSet(baseState, 'mon', item.id, 0);
+    expect(before).toBe(baseState);
+    const after = toggleSet(startWorkout(baseState, 'mon'), 'mon', item.id, 0);
+    expect(after.inProgress.completedSets[item.id][0]).toBe(true);
+  });
+
+  test('startWorkout is a no-op when a session is already running', () => {
+    const s1 = startWorkout(baseState, 'mon');
+    const s2 = startWorkout(s1, 'tue');
+    expect(s2).toBe(s1);
+  });
+
+  test('cancelWorkout drops in-progress without writing to history', () => {
+    const s = cancelWorkout(startWorkout(baseState, 'mon'));
+    expect(s.inProgress).toBeNull();
+    expect(s.history).toEqual([]);
+  });
+
+  test('finishWorkout records duration and dates from startedAt', () => {
+    // Start at a fixed instant, finish 25 minutes later.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-29T22:30:00Z'));
+    const started = startWorkout(baseState, 'mon');
+    vi.setSystemTime(new Date('2026-04-29T22:55:00Z'));
+    const finished = finishWorkout(started);
+    const entry = finished.history[0];
+    expect(entry.date).toBe('2026-04-29');
+    expect(entry.startedAt).toBe(Date.parse('2026-04-29T22:30:00Z'));
+    expect(entry.finishedAt).toBe(Date.parse('2026-04-29T22:55:00Z'));
+    expect(entry.day).toBe('mon');
+    expect(finished.inProgress).toBeNull();
+  });
+
+  test('finishWorkout uses the start date when a session crosses midnight (UTC)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-29T23:50:00Z'));
+    const started = startWorkout(baseState, 'mon');
+    vi.setSystemTime(new Date('2026-04-30T00:15:00Z'));
+    const entry = finishWorkout(started).history[0];
+    expect(entry.date).toBe('2026-04-29');
   });
 });
 


### PR DESCRIPTION
Sets are now inert until the user presses "Start workout", which stamps
inProgress.startedAt. Finishing records both startedAt and finishedAt and
attributes the entry to the start date so a session that crosses midnight
still belongs to the right day. Cancel discards the session (with confirm)
without writing to history, and the History views surface the duration.

https://claude.ai/code/session_012wQ7AKp491Gst7yWQr7fVx