### PR TITLE
tools: add /tools/ dashboard with search + categories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "astro": "^5.16.15",
         "astro-expressive-code": "^0.41.7",
         "dompurify": "^3.3.2",
+        "lucide-static": "^1.14.0",
         "marked": "^17.0.4",
         "matter-js": "^0.20.0",
         "mermaid": "^11.13.0",
@@ -6136,6 +6137,12 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/lucide-static": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/lucide-static/-/lucide-static-1.14.0.tgz",
+      "integrity": "sha512-QnAHXC1nk8IXRBmO5ee9JcPiKEVeqf06tKF0bZipxlV++bwUVqvvliC3KA+beDg2lod+WXYIhHde5pQRHkUmqA==",
+      "license": "ISC"
     },
     "node_modules/lz-string": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "astro": "^5.16.15",
     "astro-expressive-code": "^0.41.7",
     "dompurify": "^3.3.2",
+    "lucide-static": "^1.14.0",
     "marked": "^17.0.4",
     "matter-js": "^0.20.0",
     "mermaid": "^11.13.0",

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,5 +5,8 @@ const base = import.meta.env.BASE_URL;
 
 <header class="mt-4 mb-8 flex items-center justify-between gap-4">
   <a href={base} class="text-xl font-bold text-heading no-underline hover:no-underline">{`By the Rocks`}</a>
-  <ThemeToggle />
+  <div class="flex items-center gap-4">
+    <a href={`${base}tools/`} class="text-sm text-text opacity-70 hover:opacity-100 no-underline hover:underline">Tools</a>
+    <ThemeToggle />
+  </div>
 </header>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,8 +5,5 @@ const base = import.meta.env.BASE_URL;
 
 <header class="mt-4 mb-8 flex items-center justify-between gap-4">
   <a href={base} class="text-xl font-bold text-heading no-underline hover:no-underline">{`By the Rocks`}</a>
-  <div class="flex items-center gap-4">
-    <a href={`${base}tools/`} class="text-sm text-text opacity-70 hover:opacity-100 no-underline hover:underline">Tools</a>
-    <ThemeToggle />
-  </div>
+  <ThemeToggle />
 </header>

--- a/src/components/LucideIcon.astro
+++ b/src/components/LucideIcon.astro
@@ -1,0 +1,83 @@
+---
+import receipt from 'lucide-static/icons/receipt.svg?raw';
+import wallet from 'lucide-static/icons/wallet.svg?raw';
+import clock from 'lucide-static/icons/clock.svg?raw';
+import sparkles from 'lucide-static/icons/sparkles.svg?raw';
+import gift from 'lucide-static/icons/gift.svg?raw';
+import messageCircle from 'lucide-static/icons/message-circle.svg?raw';
+import treePine from 'lucide-static/icons/tree-pine.svg?raw';
+import coffee from 'lucide-static/icons/coffee.svg?raw';
+import layers from 'lucide-static/icons/layers.svg?raw';
+import dumbbell from 'lucide-static/icons/dumbbell.svg?raw';
+import terminal from 'lucide-static/icons/terminal.svg?raw';
+import languages from 'lucide-static/icons/languages.svg?raw';
+import columns2 from 'lucide-static/icons/columns-2.svg?raw';
+import imageDown from 'lucide-static/icons/image-down.svg?raw';
+import fileCode from 'lucide-static/icons/file-code.svg?raw';
+import smile from 'lucide-static/icons/smile.svg?raw';
+import fileText from 'lucide-static/icons/file-text.svg?raw';
+import qrCode from 'lucide-static/icons/qr-code.svg?raw';
+import listOrdered from 'lucide-static/icons/list-ordered.svg?raw';
+import arrowUpDown from 'lucide-static/icons/arrow-up-down.svg?raw';
+import microscope from 'lucide-static/icons/microscope.svg?raw';
+import arrowRightLeft from 'lucide-static/icons/arrow-right-left.svg?raw';
+import volume2 from 'lucide-static/icons/volume-2.svg?raw';
+import heartHandshake from 'lucide-static/icons/heart-handshake.svg?raw';
+import fileSpreadsheet from 'lucide-static/icons/file-spreadsheet.svg?raw';
+import flower from 'lucide-static/icons/flower.svg?raw';
+import heartPulse from 'lucide-static/icons/heart-pulse.svg?raw';
+import images from 'lucide-static/icons/images.svg?raw';
+import wrench from 'lucide-static/icons/wrench.svg?raw';
+import gamepad2 from 'lucide-static/icons/gamepad-2.svg?raw';
+import graduationCap from 'lucide-static/icons/graduation-cap.svg?raw';
+import presentation from 'lucide-static/icons/presentation.svg?raw';
+import heart from 'lucide-static/icons/heart.svg?raw';
+import search from 'lucide-static/icons/search.svg?raw';
+
+const ICONS: Record<string, string> = {
+  'receipt': receipt,
+  'wallet': wallet,
+  'clock': clock,
+  'sparkles': sparkles,
+  'gift': gift,
+  'message-circle': messageCircle,
+  'tree-pine': treePine,
+  'coffee': coffee,
+  'layers': layers,
+  'dumbbell': dumbbell,
+  'terminal': terminal,
+  'languages': languages,
+  'columns-2': columns2,
+  'image-down': imageDown,
+  'file-code': fileCode,
+  'smile': smile,
+  'file-text': fileText,
+  'qr-code': qrCode,
+  'list-ordered': listOrdered,
+  'arrow-up-down': arrowUpDown,
+  'microscope': microscope,
+  'arrow-right-left': arrowRightLeft,
+  'volume-2': volume2,
+  'heart-handshake': heartHandshake,
+  'file-spreadsheet': fileSpreadsheet,
+  'flower': flower,
+  'heart-pulse': heartPulse,
+  'images': images,
+  'wrench': wrench,
+  'gamepad-2': gamepad2,
+  'graduation-cap': graduationCap,
+  'presentation': presentation,
+  'heart': heart,
+  'search': search,
+};
+
+interface Props {
+  name: string;
+  class?: string;
+}
+
+const { name, class: className = 'w-5 h-5' } = Astro.props;
+const svg = ICONS[name];
+---
+
+{svg && <span class={`inline-flex items-center justify-center ${className}`} set:html={svg} />}

--- a/src/components/LucideIcon.astro
+++ b/src/components/LucideIcon.astro
@@ -33,6 +33,7 @@ import graduationCap from 'lucide-static/icons/graduation-cap.svg?raw';
 import presentation from 'lucide-static/icons/presentation.svg?raw';
 import heart from 'lucide-static/icons/heart.svg?raw';
 import search from 'lucide-static/icons/search.svg?raw';
+import pin from 'lucide-static/icons/pin.svg?raw';
 
 const ICONS: Record<string, string> = {
   'receipt': receipt,
@@ -69,6 +70,7 @@ const ICONS: Record<string, string> = {
   'presentation': presentation,
   'heart': heart,
   'search': search,
+  'pin': pin,
 };
 
 interface Props {

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -25,6 +25,8 @@ const works = defineCollection({
     url: z.string().url().optional(),
     tags: z.array(z.string()).optional(),
     pinned: z.boolean().optional().default(false),
+    category: z.string().optional(),
+    icon: z.string().optional(),
   }),
 });
 

--- a/src/content/works/bill.json
+++ b/src/content/works/bill.json
@@ -7,5 +7,7 @@
   "tags": [
     "tool",
     "finance"
-  ]
+  ],
+  "category": "finance",
+  "icon": "receipt"
 }

--- a/src/content/works/bitemporal.json
+++ b/src/content/works/bitemporal.json
@@ -7,5 +7,7 @@
   "tags": [
     "visualization",
     "clojure"
-  ]
+  ],
+  "category": "learning",
+  "icon": "clock"
 }

--- a/src/content/works/bridal-skincare.json
+++ b/src/content/works/bridal-skincare.json
@@ -3,5 +3,9 @@
   "stage": "draft",
   "date": "2026-04-09",
   "description": "Daily skincare routine tracker for the 3-month pre-wedding plan, showing AM/PM steps, LED mask schedule, and weekly treatments.",
-  "tags": ["tool"]
+  "tags": [
+    "tool"
+  ],
+  "category": "health",
+  "icon": "flower"
 }

--- a/src/content/works/chat-wrapped.json
+++ b/src/content/works/chat-wrapped.json
@@ -6,5 +6,7 @@
   "tags": [
     "presentation",
     "clojure"
-  ]
+  ],
+  "category": "talks",
+  "icon": "gift"
 }

--- a/src/content/works/chat.json
+++ b/src/content/works/chat.json
@@ -5,5 +5,7 @@
   "description": "A chat interface emulator. Type in the box at the bottom and watch messages stack above.",
   "tags": [
     "tool"
-  ]
+  ],
+  "category": "fun",
+  "icon": "message-circle"
 }

--- a/src/content/works/christmas.json
+++ b/src/content/works/christmas.json
@@ -6,5 +6,7 @@
   "tags": [
     "presentation",
     "clojure"
-  ]
+  ],
+  "category": "talks",
+  "icon": "tree-pine"
 }

--- a/src/content/works/coffee-merge.json
+++ b/src/content/works/coffee-merge.json
@@ -6,5 +6,7 @@
   "tags": [
     "game",
     "javascript"
-  ]
+  ],
+  "category": "fun",
+  "icon": "coffee"
 }

--- a/src/content/works/dual-bg-matte.json
+++ b/src/content/works/dual-bg-matte.json
@@ -6,5 +6,7 @@
   "tags": [
     "tool",
     "images"
-  ]
+  ],
+  "category": "images",
+  "icon": "layers"
 }

--- a/src/content/works/exercise.json
+++ b/src/content/works/exercise.json
@@ -6,5 +6,7 @@
   "tags": [
     "tool",
     "fitness"
-  ]
+  ],
+  "category": "health",
+  "icon": "dumbbell"
 }

--- a/src/content/works/glance.json
+++ b/src/content/works/glance.json
@@ -7,5 +7,7 @@
   "tags": [
     "tool",
     "ai"
-  ]
+  ],
+  "category": "ai",
+  "icon": "terminal"
 }

--- a/src/content/works/hindi-srs.json
+++ b/src/content/works/hindi-srs.json
@@ -6,5 +6,7 @@
   "tags": [
     "tool",
     "learning"
-  ]
+  ],
+  "category": "learning",
+  "icon": "languages"
 }

--- a/src/content/works/image-compare.json
+++ b/src/content/works/image-compare.json
@@ -6,5 +6,7 @@
   "tags": [
     "tool",
     "images"
-  ]
+  ],
+  "category": "images",
+  "icon": "columns-2"
 }

--- a/src/content/works/image-compress.json
+++ b/src/content/works/image-compress.json
@@ -2,9 +2,11 @@
   "title": "Image Compress",
   "stage": "draft",
   "date": "2026-03-11",
-  "description": "Compress and resize images in the browser. No upload \u2014 everything stays local.",
+  "description": "Compress and resize images in the browser. No upload — everything stays local.",
   "tags": [
     "tool",
     "images"
-  ]
+  ],
+  "category": "images",
+  "icon": "image-down"
 }

--- a/src/content/works/markdown-preview.json
+++ b/src/content/works/markdown-preview.json
@@ -5,5 +5,7 @@
   "description": "Write and preview GitHub Flavoured Markdown with Mermaid diagram support. Text is saved to local storage.",
   "tags": [
     "tool"
-  ]
+  ],
+  "category": "utilities",
+  "icon": "file-code"
 }

--- a/src/content/works/mood-tracker.json
+++ b/src/content/works/mood-tracker.json
@@ -7,5 +7,7 @@
   "tags": [
     "tool",
     "personal"
-  ]
+  ],
+  "category": "health",
+  "icon": "smile"
 }

--- a/src/content/works/pdf-compress.json
+++ b/src/content/works/pdf-compress.json
@@ -6,5 +6,7 @@
   "tags": [
     "tool",
     "pdf"
-  ]
+  ],
+  "category": "utilities",
+  "icon": "file-text"
 }

--- a/src/content/works/qr-code.json
+++ b/src/content/works/qr-code.json
@@ -5,5 +5,7 @@
   "description": "Generate a QR code from text or a URL and download it as a PNG.",
   "tags": [
     "tool"
-  ]
+  ],
+  "category": "utilities",
+  "icon": "qr-code"
 }

--- a/src/content/works/recommender.json
+++ b/src/content/works/recommender.json
@@ -7,5 +7,7 @@
   "tags": [
     "tool",
     "ai"
-  ]
+  ],
+  "category": "ai",
+  "icon": "list-ordered"
 }

--- a/src/content/works/sorting-comparator.json
+++ b/src/content/works/sorting-comparator.json
@@ -7,5 +7,7 @@
     "tool",
     "data",
     "visualization"
-  ]
+  ],
+  "category": "learning",
+  "icon": "arrow-up-down"
 }

--- a/src/content/works/test-reader.json
+++ b/src/content/works/test-reader.json
@@ -7,5 +7,7 @@
     "tool",
     "ai",
     "images"
-  ]
+  ],
+  "category": "health",
+  "icon": "microscope"
 }

--- a/src/content/works/transit-converter.json
+++ b/src/content/works/transit-converter.json
@@ -6,5 +6,7 @@
   "tags": [
     "tool",
     "clojure"
-  ]
+  ],
+  "category": "utilities",
+  "icon": "arrow-right-left"
 }

--- a/src/content/works/tts.json
+++ b/src/content/works/tts.json
@@ -6,5 +6,7 @@
   "tags": [
     "tool",
     "ai"
-  ]
+  ],
+  "category": "ai",
+  "icon": "volume-2"
 }

--- a/src/content/works/wedding-celebration.json
+++ b/src/content/works/wedding-celebration.json
@@ -7,5 +7,7 @@
   "tags": [
     "personal",
     "tool"
-  ]
+  ],
+  "category": "personal",
+  "icon": "heart-handshake"
 }

--- a/src/content/works/ynab-reimbursement.json
+++ b/src/content/works/ynab-reimbursement.json
@@ -6,5 +6,7 @@
   "tags": [
     "tool",
     "finance"
-  ]
+  ],
+  "category": "finance",
+  "icon": "file-spreadsheet"
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -43,6 +43,8 @@ const rest = allItems.filter(i => !i.pinned).sort((a, b) => b.date.getTime() - a
 ---
 
 <Layout>
+  <a href={`${base}tools/`} class="text-sm text-text opacity-60 hover:opacity-100 no-underline hover:underline">All tools →</a>
+
   {pinned.length > 0 && (
     <>
       <h2 class="text-sm font-semibold text-heading mt-6 mb-1 uppercase tracking-wide opacity-60">Pinned</h2>

--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -1,0 +1,164 @@
+---
+import { Image } from 'astro:assets';
+import { getCollection } from 'astro:content';
+import Layout from '../../layouts/Layout.astro';
+import LucideIcon from '../../components/LucideIcon.astro';
+
+const base = import.meta.env.BASE_URL;
+
+const CATEGORIES = [
+  { id: 'finance', name: 'Finance', icon: 'wallet' },
+  { id: 'health', name: 'Health', icon: 'heart-pulse' },
+  { id: 'ai', name: 'AI', icon: 'sparkles' },
+  { id: 'images', name: 'Images', icon: 'images' },
+  { id: 'utilities', name: 'Utilities', icon: 'wrench' },
+  { id: 'fun', name: 'Fun', icon: 'gamepad-2' },
+  { id: 'learning', name: 'Learning', icon: 'graduation-cap' },
+  { id: 'talks', name: 'Talks', icon: 'presentation' },
+  { id: 'personal', name: 'Personal', icon: 'heart' },
+];
+
+const works = await getCollection('works');
+
+const screenshots = import.meta.glob<{ default: import('astro').ImageMetadata }>(
+  '../../assets/works/*.png',
+  { eager: true }
+);
+
+function workUrl(work: { id: string; data: { url?: string } }) {
+  return work.data.url || `${base}${work.id.replace('.json', '')}/`;
+}
+
+function screenshot(work: { id: string }) {
+  const key = `../../assets/works/${work.id.replace('.json', '')}.png`;
+  return screenshots[key]?.default;
+}
+
+const grouped = CATEGORIES.map(cat => {
+  const items = works
+    .filter(w => w.data.category === cat.id)
+    .sort((a, b) => {
+      const da = (a.data.updated ?? a.data.date).getTime();
+      const db = (b.data.updated ?? b.data.date).getTime();
+      return db - da;
+    });
+  return { ...cat, items };
+}).filter(c => c.items.length > 0);
+---
+
+<Layout title="Tools" description="A dashboard of all the tools, talks and toys on this site.">
+  <h1 class="text-2xl font-bold text-heading mt-4 mb-2">Tools</h1>
+  <p class="text-sm opacity-70 mt-0 mb-4">Search or scroll. {works.length} things across {grouped.length} categories.</p>
+
+  <label class="relative flex items-center gap-2 mb-6 border border-border rounded-md px-3 py-2 focus-within:border-link transition-colors">
+    <LucideIcon name="search" class="w-4 h-4 opacity-50" />
+    <input
+      id="tools-search"
+      type="search"
+      placeholder="Search tools…"
+      autocomplete="off"
+      class="flex-1 bg-transparent outline-none border-0 text-sm text-text placeholder:opacity-40"
+    />
+  </label>
+
+  <p id="tools-empty" class="hidden text-sm opacity-60 italic mt-8">No tools match that search.</p>
+
+  <div class="md:[column-count:2] md:gap-x-6">
+    {grouped.map(cat => (
+      <section
+        class="mb-8 break-inside-avoid"
+        data-category={cat.id}
+      >
+        <h2 class="flex items-center gap-2 text-sm font-semibold text-heading uppercase tracking-wide opacity-70 mt-0 mb-2 pb-1 border-b border-border">
+          <LucideIcon name={cat.icon} class="w-4 h-4" />
+          <span>{cat.name}</span>
+        </h2>
+
+        <ul class="flex flex-col gap-1 list-none p-0 m-0">
+          {cat.items.map(work => {
+            const img = screenshot(work);
+            const url = workUrl(work);
+            const haystack = [
+              work.data.title,
+              work.data.description,
+              cat.name,
+              cat.id,
+              ...(work.data.tags ?? []),
+            ].join(' ').toLowerCase();
+            return (
+              <li
+                class="tool-row flex items-stretch gap-3 py-1.5"
+                data-tool
+                data-search={haystack}
+              >
+                <a
+                  href={url}
+                  class="flex items-center justify-center w-9 h-9 shrink-0 rounded-md border border-border text-text no-underline hover:bg-code-bg hover:text-link transition-colors"
+                  aria-label={work.data.title}
+                >
+                  {work.data.icon && <LucideIcon name={work.data.icon} class="w-5 h-5" />}
+                </a>
+
+                <div class="flex flex-col justify-center min-w-0 flex-1">
+                  <h3 class="text-sm font-semibold m-0 truncate">
+                    <a href={url} class="text-link visited:text-link-visited no-underline hover:underline">{work.data.title}</a>
+                  </h3>
+                  <p class="text-xs m-0 mt-0.5 opacity-75 leading-snug line-clamp-2">{work.data.description}</p>
+                </div>
+
+                {img && (
+                  <a href={url} class="block w-12 h-12 shrink-0 rounded overflow-hidden">
+                    <Image
+                      src={img}
+                      alt={`Screenshot of ${work.data.title}`}
+                      class="w-full h-full object-cover object-center"
+                      loading="lazy"
+                      widths={[96, 192]}
+                      sizes="48px"
+                    />
+                  </a>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+    ))}
+  </div>
+
+  <script>
+    const input = document.getElementById('tools-search') as HTMLInputElement | null;
+    const empty = document.getElementById('tools-empty');
+    const sections = Array.from(document.querySelectorAll<HTMLElement>('[data-category]'));
+
+    function applyFilter(query: string) {
+      const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+      let anyVisible = false;
+
+      for (const section of sections) {
+        const rows = Array.from(section.querySelectorAll<HTMLElement>('[data-tool]'));
+        let visibleCount = 0;
+        for (const row of rows) {
+          const hay = row.dataset.search ?? '';
+          const matches = terms.every(t => hay.includes(t));
+          row.style.display = matches ? '' : 'none';
+          if (matches) visibleCount++;
+        }
+        section.style.display = visibleCount === 0 ? 'none' : '';
+        if (visibleCount > 0) anyVisible = true;
+      }
+
+      if (empty) empty.style.display = anyVisible ? 'none' : '';
+    }
+
+    input?.addEventListener('input', () => applyFilter(input.value));
+
+    // Keyboard shortcut: '/' focuses search
+    document.addEventListener('keydown', (e) => {
+      if (e.key === '/' && document.activeElement !== input && !(document.activeElement instanceof HTMLInputElement)) {
+        e.preventDefault();
+        input?.focus();
+      }
+    });
+  </script>
+</Layout>

--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -29,6 +29,10 @@ function workUrl(work: { id: string; data: { url?: string } }) {
   return work.data.url || `${base}${work.id.replace('.json', '')}/`;
 }
 
+function workSlug(work: { id: string }) {
+  return work.id.replace('.json', '');
+}
+
 function screenshot(work: { id: string }) {
   const key = `../../assets/works/${work.id.replace('.json', '')}.png`;
   return screenshots[key]?.default;
@@ -63,6 +67,14 @@ const grouped = CATEGORIES.map(cat => {
 
   <p id="tools-empty" class="hidden text-sm opacity-60 italic mt-8">No tools match that search.</p>
 
+  <section id="pinned-section" class="hidden mb-8" data-pinned-section>
+    <h2 class="flex items-center gap-2 text-sm font-semibold text-heading uppercase tracking-wide opacity-70 mt-0 mb-2 pb-1 border-b border-border">
+      <LucideIcon name="pin" class="w-4 h-4" />
+      <span>Pinned</span>
+    </h2>
+    <ul id="pinned-list" class="flex flex-col gap-1 list-none p-0 m-0"></ul>
+  </section>
+
   <div class="md:[column-count:2] md:gap-x-6">
     {grouped.map(cat => (
       <section
@@ -78,6 +90,7 @@ const grouped = CATEGORIES.map(cat => {
           {cat.items.map(work => {
             const img = screenshot(work);
             const url = workUrl(work);
+            const slug = workSlug(work);
             const haystack = [
               work.data.title,
               work.data.description,
@@ -87,8 +100,10 @@ const grouped = CATEGORIES.map(cat => {
             ].join(' ').toLowerCase();
             return (
               <li
-                class="tool-row flex items-stretch gap-3 py-1.5"
+                class="tool-row relative flex items-stretch gap-3 py-1.5 pr-7"
                 data-tool
+                data-slug={slug}
+                data-pinned="false"
                 data-search={haystack}
               >
                 <a
@@ -118,6 +133,15 @@ const grouped = CATEGORIES.map(cat => {
                     />
                   </a>
                 )}
+
+                <button
+                  type="button"
+                  data-pin
+                  aria-label={`Pin ${work.data.title}`}
+                  class="pin-btn absolute top-1 right-0 flex items-center justify-center w-6 h-6 text-text cursor-pointer"
+                >
+                  <LucideIcon name="pin" class="w-3.5 h-3.5" />
+                </button>
               </li>
             );
           })}
@@ -126,16 +150,103 @@ const grouped = CATEGORIES.map(cat => {
     ))}
   </div>
 
+  <style>
+    .pin-btn {
+      opacity: 0.25;
+      transition: opacity 0.15s, color 0.15s, transform 0.15s;
+    }
+    .pin-btn:hover,
+    .pin-btn:focus-visible {
+      opacity: 0.7;
+    }
+    .tool-row[data-pinned="true"] .pin-btn {
+      opacity: 1;
+      color: var(--color-link);
+      transform: rotate(45deg);
+    }
+    .tool-row[data-pinned="true"] .pin-btn:hover {
+      opacity: 0.85;
+    }
+  </style>
+
   <script>
+    const STORAGE_KEY = 'tools.pins.v1';
+
     const input = document.getElementById('tools-search') as HTMLInputElement | null;
     const empty = document.getElementById('tools-empty');
-    const sections = Array.from(document.querySelectorAll<HTMLElement>('[data-category]'));
+    const pinnedSection = document.getElementById('pinned-section') as HTMLElement | null;
+    const pinnedList = document.getElementById('pinned-list') as HTMLElement | null;
+    const categorySections = Array.from(document.querySelectorAll<HTMLElement>('[data-category]'));
+
+    function loadPins(): Set<string> {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return new Set();
+        const arr = JSON.parse(raw);
+        return new Set(Array.isArray(arr) ? arr.filter(s => typeof s === 'string') : []);
+      } catch {
+        return new Set();
+      }
+    }
+
+    function savePins(pins: Set<string>) {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify([...pins]));
+      } catch {}
+    }
+
+    const pins = loadPins();
+
+    function rowsForSlug(slug: string): HTMLElement[] {
+      return Array.from(document.querySelectorAll<HTMLElement>(`[data-tool][data-slug="${CSS.escape(slug)}"]`));
+    }
+
+    function originalRowForSlug(slug: string): HTMLElement | null {
+      return document.querySelector<HTMLElement>(`[data-category] [data-tool][data-slug="${CSS.escape(slug)}"]`);
+    }
+
+    function addPinnedClone(slug: string) {
+      if (!pinnedList) return;
+      if (pinnedList.querySelector(`[data-slug="${CSS.escape(slug)}"]`)) return;
+      const original = originalRowForSlug(slug);
+      if (!original) return;
+      const clone = original.cloneNode(true) as HTMLElement;
+      clone.dataset.pinned = 'true';
+      pinnedList.appendChild(clone);
+    }
+
+    function removePinnedClone(slug: string) {
+      pinnedList?.querySelector(`[data-slug="${CSS.escape(slug)}"]`)?.remove();
+    }
+
+    function setPinned(slug: string, pinned: boolean) {
+      if (pinned) pins.add(slug);
+      else pins.delete(slug);
+      savePins(pins);
+
+      for (const row of rowsForSlug(slug)) {
+        row.dataset.pinned = pinned ? 'true' : 'false';
+      }
+
+      if (pinned) addPinnedClone(slug);
+      else removePinnedClone(slug);
+
+      applyFilter(input?.value ?? '');
+    }
+
+    // Hydrate from localStorage: mark + clone any pinned rows
+    for (const slug of pins) {
+      for (const row of rowsForSlug(slug)) {
+        row.dataset.pinned = 'true';
+      }
+      addPinnedClone(slug);
+    }
 
     function applyFilter(query: string) {
       const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
       let anyVisible = false;
 
-      for (const section of sections) {
+      for (const section of categorySections) {
         const rows = Array.from(section.querySelectorAll<HTMLElement>('[data-tool]'));
         let visibleCount = 0;
         for (const row of rows) {
@@ -148,12 +259,55 @@ const grouped = CATEGORIES.map(cat => {
         if (visibleCount > 0) anyVisible = true;
       }
 
+      if (pinnedList && pinnedSection) {
+        const pinnedRows = Array.from(pinnedList.querySelectorAll<HTMLElement>('[data-tool]'));
+        let pinnedVisible = 0;
+        for (const row of pinnedRows) {
+          const hay = row.dataset.search ?? '';
+          const matches = terms.every(t => hay.includes(t));
+          row.style.display = matches ? '' : 'none';
+          if (matches) pinnedVisible++;
+        }
+        pinnedSection.style.display = pinnedRows.length > 0 && pinnedVisible > 0 ? '' : 'none';
+        if (pinnedVisible > 0) anyVisible = true;
+      }
+
       if (empty) empty.style.display = anyVisible ? 'none' : '';
     }
 
+    applyFilter('');
+
     input?.addEventListener('input', () => applyFilter(input.value));
 
-    // Keyboard shortcut: '/' focuses search
+    document.addEventListener('click', (e) => {
+      const target = e.target as Element | null;
+      const btn = target?.closest('[data-pin]') as HTMLElement | null;
+      if (!btn) return;
+      e.preventDefault();
+      const row = btn.closest('[data-tool]') as HTMLElement | null;
+      const slug = row?.dataset.slug;
+      if (!slug) return;
+      setPinned(slug, !pins.has(slug));
+    });
+
+    // Sync across tabs
+    window.addEventListener('storage', (e) => {
+      if (e.key !== STORAGE_KEY) return;
+      const next = loadPins();
+      const all = new Set([...pins, ...next]);
+      for (const slug of all) {
+        const wasPinned = pins.has(slug);
+        const isPinned = next.has(slug);
+        if (wasPinned === isPinned) continue;
+        if (isPinned) pins.add(slug); else pins.delete(slug);
+        for (const row of rowsForSlug(slug)) {
+          row.dataset.pinned = isPinned ? 'true' : 'false';
+        }
+        if (isPinned) addPinnedClone(slug); else removePinnedClone(slug);
+      }
+      applyFilter(input?.value ?? '');
+    });
+
     document.addEventListener('keydown', (e) => {
       if (e.key === '/' && document.activeElement !== input && !(document.activeElement instanceof HTMLInputElement)) {
         e.preventDefault();

--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -244,7 +244,7 @@ const grouped = CATEGORIES.map(cat => {
 
     function applyFilter(query: string) {
       const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
-      let anyVisible = false;
+      let anyCategoryVisible = false;
 
       for (const section of categorySections) {
         const rows = Array.from(section.querySelectorAll<HTMLElement>('[data-tool]'));
@@ -256,23 +256,18 @@ const grouped = CATEGORIES.map(cat => {
           if (matches) visibleCount++;
         }
         section.classList.toggle('hidden', visibleCount === 0);
-        if (visibleCount > 0) anyVisible = true;
+        if (visibleCount > 0) anyCategoryVisible = true;
       }
 
       if (pinnedList && pinnedSection) {
         const pinnedRows = Array.from(pinnedList.querySelectorAll<HTMLElement>('[data-tool]'));
-        let pinnedVisible = 0;
         for (const row of pinnedRows) {
-          const hay = row.dataset.search ?? '';
-          const matches = terms.every(t => hay.includes(t));
-          row.classList.toggle('hidden', !matches);
-          if (matches) pinnedVisible++;
+          row.classList.remove('hidden');
         }
-        pinnedSection.classList.toggle('hidden', pinnedRows.length === 0 || pinnedVisible === 0);
-        if (pinnedVisible > 0) anyVisible = true;
+        pinnedSection.classList.toggle('hidden', pinnedRows.length === 0);
       }
 
-      empty?.classList.toggle('hidden', anyVisible);
+      empty?.classList.toggle('hidden', anyCategoryVisible);
     }
 
     applyFilter('');

--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -264,7 +264,8 @@ const grouped = CATEGORIES.map(cat => {
         for (const row of pinnedRows) {
           row.classList.remove('hidden');
         }
-        pinnedSection.classList.toggle('hidden', pinnedRows.length === 0);
+        const hasQuery = terms.length > 0;
+        pinnedSection.classList.toggle('hidden', hasQuery || pinnedRows.length === 0);
       }
 
       empty?.classList.toggle('hidden', anyCategoryVisible);

--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -252,10 +252,10 @@ const grouped = CATEGORIES.map(cat => {
         for (const row of rows) {
           const hay = row.dataset.search ?? '';
           const matches = terms.every(t => hay.includes(t));
-          row.style.display = matches ? '' : 'none';
+          row.classList.toggle('hidden', !matches);
           if (matches) visibleCount++;
         }
-        section.style.display = visibleCount === 0 ? 'none' : '';
+        section.classList.toggle('hidden', visibleCount === 0);
         if (visibleCount > 0) anyVisible = true;
       }
 
@@ -265,14 +265,14 @@ const grouped = CATEGORIES.map(cat => {
         for (const row of pinnedRows) {
           const hay = row.dataset.search ?? '';
           const matches = terms.every(t => hay.includes(t));
-          row.style.display = matches ? '' : 'none';
+          row.classList.toggle('hidden', !matches);
           if (matches) pinnedVisible++;
         }
-        pinnedSection.style.display = pinnedRows.length > 0 && pinnedVisible > 0 ? '' : 'none';
+        pinnedSection.classList.toggle('hidden', pinnedRows.length === 0 || pinnedVisible === 0);
         if (pinnedVisible > 0) anyVisible = true;
       }
 
-      if (empty) empty.style.display = anyVisible ? 'none' : '';
+      empty?.classList.toggle('hidden', anyVisible);
     }
 
     applyFilter('');


### PR DESCRIPTION
Categorises all 24 works into 9 groups (finance, health, AI, images,
utilities, fun, learning, talks, personal) with a lucide icon per tool.
Mobile is a single column; desktop flows category panels into 2 columns.
Live client-side search filters tools and hides empty sections; '/'
focuses the input.

https://claude.ai/code/session_01NsqbcA7Njj5xJzHsap7o9P