### PR TITLE
coffee-merge: dedupe leaderboard by name, show top 5 + the user's row

### DIFF
--- a/src/pages/coffee-merge/_app/game.js
+++ b/src/pages/coffee-merge/_app/game.js
@@ -176,7 +176,8 @@ async function deleteLiveSession() {
 }
 
 async function fetchLiveRivals() {
-  const cutoff = new Date(Date.now() - LIVE_FRESH_MS).toISOString();
+  // PocketBase filter wants "YYYY-MM-DD HH:MM:SS.sssZ" (space, not T).
+  const cutoff = new Date(Date.now() - LIVE_FRESH_MS).toISOString().replace('T', ' ');
   let f = `game="${GAME_ID}" && updated>"${cutoff}"`;
   if (sessionId) f += ` && id!="${sessionId}"`;
   try {

--- a/src/pages/coffee-merge/_app/game.js
+++ b/src/pages/coffee-merge/_app/game.js
@@ -99,17 +99,31 @@ const overTimers = new Map();
 const NAME_KEY = 'coffee-merge:lastName';
 const STATE_KEY = 'coffee-merge:gameState';
 const SAVE_INTERVAL_MS = 1000;
-const MAX_ENTRIES = 10;
+const TOP_ENTRIES = 5;
+// Overfetch so client-side dedup-by-name still yields enough unique users
+// even when the top of the table is dominated by repeat submissions.
+const FETCH_SIZE = 200;
 const PB_URL = 'https://pb.bythe.rocks';
 const GAME_ID = 'coffee-merge';
 
+function dedupeByName(entries) {
+  const seen = new Set();
+  const out = [];
+  for (const e of entries) {
+    if (seen.has(e.name)) continue;
+    seen.add(e.name);
+    out.push(e);
+  }
+  return out;
+}
+
 async function fetchLeaderboard() {
   const filter = encodeURIComponent(`game="${GAME_ID}"`);
-  const url = `${PB_URL}/api/collections/scores/records?filter=${filter}&sort=-score&perPage=${MAX_ENTRIES}`;
+  const url = `${PB_URL}/api/collections/scores/records?filter=${filter}&sort=-score&perPage=${FETCH_SIZE}`;
   const res = await fetch(url);
   if (!res.ok) throw new Error(`Leaderboard fetch failed: ${res.status}`);
   const data = await res.json();
-  return data.items || [];
+  return dedupeByName(data.items || []);
 }
 function loadLastName() {
   return localStorage.getItem(NAME_KEY) || '';
@@ -177,9 +191,35 @@ function setLeaderboardMessage(text) {
   list.appendChild(li);
 }
 
+function appendLeaderboardRow(list, entry, rank, opts = {}) {
+  const li = document.createElement('li');
+  if (opts.isUser) li.classList.add('is-user');
+  if (opts.separated) li.classList.add('separated');
+  const rankEl = document.createElement('span');
+  rankEl.className = 'rank';
+  rankEl.textContent = rank === 1 ? '👑' : `#${rank}`;
+  const name = document.createElement('span');
+  name.className = 'name';
+  name.textContent = entry.name;
+  const sc = document.createElement('span');
+  sc.className = 'score';
+  sc.textContent = entry.score;
+  li.append(rankEl, name);
+  if (typeof entry.tier === 'number' && TIERS[entry.tier]) {
+    const drink = document.createElement('img');
+    drink.className = 'drink';
+    drink.src = TIERS[entry.tier].img.src;
+    drink.alt = '';
+    li.append(drink);
+  }
+  li.append(sc);
+  list.appendChild(li);
+}
+
 async function renderLeaderboard() {
   const list = document.getElementById('leaderboardList');
   setLeaderboardMessage('loading…');
+  const userName = loadLastName();
   let entries;
   try {
     entries = await fetchLeaderboard();
@@ -195,28 +235,18 @@ async function renderLeaderboard() {
     list.appendChild(li);
     return;
   }
-  entries.forEach((entry, i) => {
-    const li = document.createElement('li');
-    const rank = document.createElement('span');
-    rank.className = 'rank';
-    rank.textContent = i === 0 ? '👑' : `#${i + 1}`;
-    const name = document.createElement('span');
-    name.className = 'name';
-    name.textContent = entry.name;
-    const sc = document.createElement('span');
-    sc.className = 'score';
-    sc.textContent = entry.score;
-    li.append(rank, name);
-    if (typeof entry.tier === 'number' && TIERS[entry.tier]) {
-      const drink = document.createElement('img');
-      drink.className = 'drink';
-      drink.src = TIERS[entry.tier].img.src;
-      drink.alt = '';
-      li.append(drink);
-    }
-    li.append(sc);
-    list.appendChild(li);
+  const userIdx = userName ? entries.findIndex(e => e.name === userName) : -1;
+  const top = entries.slice(0, TOP_ENTRIES);
+  top.forEach((entry, i) => {
+    const isUser = i === userIdx;
+    appendLeaderboardRow(list, entry, i + 1, { isUser });
   });
+  if (userIdx >= TOP_ENTRIES) {
+    appendLeaderboardRow(list, entries[userIdx], userIdx + 1, {
+      isUser: true,
+      separated: true,
+    });
+  }
 }
 
 function showLeaderboard() {

--- a/src/pages/coffee-merge/_app/game.js
+++ b/src/pages/coffee-merge/_app/game.js
@@ -106,6 +106,226 @@ const FETCH_SIZE = 200;
 const PB_URL = 'https://pb.bythe.rocks';
 const GAME_ID = 'coffee-merge';
 
+// Live ladder: each player upserts a row in `live_sessions` while playing,
+// and polls others' rows to fill the two flanking slots around their score.
+const LIVE_FRESH_MS = 15000;
+const LIVE_PATCH_INTERVAL_MS = 2000;
+const LIVE_POLL_INTERVAL_MS = 3000;
+
+let sessionId = null;
+let liveTop = null;
+let liveAbove = null;
+let liveBelow = null;
+let prevWindowKeys = [];
+
+function liveUrl(suffix = '') {
+  return `${PB_URL}/api/collections/live_sessions/records${suffix}`;
+}
+
+async function createLiveSession() {
+  const playerName = loadLastName() || 'Player';
+  try {
+    const res = await fetch(liveUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ game: GAME_ID, name: playerName, score: 0, tier: 0 }),
+    });
+    if (!res.ok) return;
+    const data = await res.json();
+    sessionId = data.id;
+  } catch {}
+}
+
+let lastPatchAt = 0;
+let pendingPatchTimer = null;
+function scheduleLivePatch() {
+  const wait = Math.max(0, LIVE_PATCH_INTERVAL_MS - (Date.now() - lastPatchAt));
+  if (wait === 0) {
+    sendLivePatch();
+  } else if (!pendingPatchTimer) {
+    pendingPatchTimer = setTimeout(() => {
+      pendingPatchTimer = null;
+      sendLivePatch();
+    }, wait);
+  }
+}
+
+async function sendLivePatch() {
+  if (!sessionId) return;
+  lastPatchAt = Date.now();
+  try {
+    await fetch(liveUrl(`/${sessionId}`), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ score, tier: maxTier }),
+    });
+  } catch {}
+}
+
+async function deleteLiveSession() {
+  if (!sessionId) return;
+  const id = sessionId;
+  sessionId = null;
+  if (pendingPatchTimer) {
+    clearTimeout(pendingPatchTimer);
+    pendingPatchTimer = null;
+  }
+  try {
+    await fetch(liveUrl(`/${id}`), { method: 'DELETE' });
+  } catch {}
+}
+
+async function fetchLiveRivals() {
+  const cutoff = new Date(Date.now() - LIVE_FRESH_MS).toISOString();
+  let f = `game="${GAME_ID}" && updated>"${cutoff}"`;
+  if (sessionId) f += ` && id!="${sessionId}"`;
+  try {
+    const res = await fetch(liveUrl(`?filter=${encodeURIComponent(f)}&perPage=20`));
+    if (!res.ok) return [];
+    const data = await res.json();
+    return data.items || [];
+  } catch { return []; }
+}
+
+async function fetchTopOne() {
+  const f = encodeURIComponent(`game="${GAME_ID}"`);
+  try {
+    const res = await fetch(`${PB_URL}/api/collections/scores/records?filter=${f}&sort=-score&perPage=1`);
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.items?.[0] || null;
+  } catch { return null; }
+}
+
+let pollTimer = null;
+function startLivePolling() {
+  if (pollTimer) return;
+  pollLive();
+  pollTimer = setInterval(pollLive, LIVE_POLL_INTERVAL_MS);
+}
+function stopLivePolling() {
+  if (pollTimer) clearInterval(pollTimer);
+  pollTimer = null;
+}
+
+async function pollLive() {
+  const [rivals, top] = await Promise.all([fetchLiveRivals(), fetchTopOne()]);
+  liveTop = top
+    ? { id: `top:${top.id}`, name: top.name, score: top.score, kind: 'top' }
+    : null;
+  liveAbove = null;
+  liveBelow = null;
+  for (const r of rivals) {
+    if (r.score > score) {
+      if (!liveAbove || r.score < liveAbove.score) {
+        liveAbove = { id: `live:${r.id}`, name: r.name, score: r.score, kind: 'live' };
+      }
+    } else if (r.score < score) {
+      if (!liveBelow || r.score > liveBelow.score) {
+        liveBelow = { id: `live:${r.id}`, name: r.name, score: r.score, kind: 'live' };
+      }
+    }
+  }
+  renderLadder();
+}
+
+function computeLadderWindow() {
+  const you = { id: 'you', name: 'YOU', score, kind: 'you' };
+  const candidates = [you];
+  // Drop the top fallback if a live rival has the same name — the live row is more meaningful.
+  let topShow = liveTop;
+  if (topShow && (liveAbove?.name === topShow.name || liveBelow?.name === topShow.name)) {
+    topShow = null;
+  }
+  if (topShow) candidates.push(topShow);
+  if (liveAbove) candidates.push(liveAbove);
+  if (liveBelow) candidates.push(liveBelow);
+  candidates.sort((a, b) => b.score - a.score);
+  const yourIdx = candidates.findIndex(c => c.kind === 'you');
+  const start = Math.max(0, yourIdx - 1);
+  return candidates.slice(start, start + 3);
+}
+
+function renderLadder() {
+  const ladder = document.getElementById('ladder');
+  if (!ladder) return;
+  const slots = computeLadderWindow();
+  const newKeys = slots.map(c => c.id);
+
+  // FLIP: capture previous row positions by id so persistent rows can slide.
+  const oldTops = new Map();
+  for (const li of ladder.children) {
+    oldTops.set(li.dataset.id, li.getBoundingClientRect().top);
+  }
+
+  ladder.innerHTML = '';
+  for (const c of slots) {
+    const li = document.createElement('li');
+    li.className = `rung is-${c.kind}`;
+    li.dataset.id = c.id;
+    const left = document.createElement('span');
+    left.className = 'rung-name';
+    if (c.kind === 'live' || c.kind === 'top') {
+      const dot = document.createElement('span');
+      dot.className = `rung-status ${c.kind}`;
+      left.appendChild(dot);
+    }
+    left.appendChild(document.createTextNode(c.name || ''));
+    const right = document.createElement('span');
+    right.className = 'rung-score';
+    right.textContent = c.score;
+    li.append(left, right);
+    ladder.appendChild(li);
+  }
+
+  // FLIP: invert + play for rows that moved.
+  for (const li of ladder.children) {
+    const oldTop = oldTops.get(li.dataset.id);
+    if (oldTop === undefined) continue;
+    const dy = oldTop - li.getBoundingClientRect().top;
+    if (!dy) continue;
+    li.style.transition = 'none';
+    li.style.transform = `translateY(${dy}px)`;
+    requestAnimationFrame(() => {
+      li.style.transition = '';
+      li.style.transform = '';
+    });
+  }
+
+  const lineupChanged =
+    newKeys.length !== prevWindowKeys.length ||
+    newKeys.some((k, i) => k !== prevWindowKeys[i]);
+  if (lineupChanged && prevWindowKeys.length > 0) {
+    const youRow = ladder.querySelector('.is-you');
+    if (youRow) {
+      youRow.classList.remove('pulse');
+      void youRow.offsetWidth;
+      youRow.classList.add('pulse');
+    }
+    const wasTop = prevWindowKeys[0] === 'you';
+    const isTop = newKeys[0] === 'you';
+    // Only celebrate when there's actually someone to overtake.
+    if (isTop && !wasTop && newKeys.length > 1) fireTopConfetti();
+  }
+  prevWindowKeys = newKeys;
+}
+
+function fireTopConfetti() {
+  const palette = ['#ffd700', '#ff6f3d', '#4ade80', '#60a5fa', '#f472b6', '#fff5c2'];
+  for (let i = 0; i < 70; i++) {
+    particles.push({
+      x: PF_LEFT + Math.random() * PF_W,
+      y: PF_TOP + 4,
+      vx: (Math.random() - 0.5) * 3,
+      vy: 1 + Math.random() * 2.5,
+      life: 90 + Math.random() * 50, max: 140,
+      color: palette[i % palette.length],
+      size: 3 + Math.random() * 2.5,
+      gravity: 0.16,
+    });
+  }
+}
+
 function dedupeByName(entries) {
   const seen = new Set();
   const out = [];
@@ -262,7 +482,6 @@ function startGame() {
   }
   score = 0;
   maxTier = 0;
-  document.getElementById('scoreVal').textContent = 0;
   particles = [];
   merges = [];
   overTimers.clear();
@@ -276,6 +495,11 @@ function startGame() {
   document.getElementById('gameover').classList.remove('show');
   clearState();
   startSaveTimer();
+  prevWindowKeys = [];
+  liveAbove = liveBelow = liveTop = null;
+  renderLadder();
+  createLiveSession();
+  startLivePolling();
 }
 
 function resumeGame(state) {
@@ -296,7 +520,6 @@ function resumeGame(state) {
     Body.setAngularVelocity(drink, d.av || 0);
     World.add(engine.world, drink);
   }
-  document.getElementById('scoreVal').textContent = score;
   document.getElementById('nextImg').src = TIERS[nextTier].img.src;
   gameOver = false;
   aiming = true;
@@ -304,11 +527,18 @@ function resumeGame(state) {
   document.body.classList.remove('menu');
   document.getElementById('gameover').classList.remove('show');
   startSaveTimer();
+  prevWindowKeys = [];
+  liveAbove = liveBelow = liveTop = null;
+  renderLadder();
+  createLiveSession();
+  startLivePolling();
 }
 
 function endGame() {
   gameOver = true;
   stopSaveTimer();
+  stopLivePolling();
+  deleteLiveSession();
   clearState();
   document.getElementById('finalScore').textContent = score;
   const input = document.getElementById('nameInput');
@@ -423,7 +653,8 @@ Events.on(engine, 'collisionStart', (event) => {
     } else {
       score += 600;
     }
-    document.getElementById('scoreVal').textContent = score;
+    renderLadder();
+    scheduleLivePatch();
   }
 });
 
@@ -453,7 +684,12 @@ function checkGameOver() {
 function updateEffects() {
   particles = particles.filter(p => {
     p.x += p.vx; p.y += p.vy;
-    p.vx *= 0.93; p.vy *= 0.93;
+    if (p.gravity) {
+      p.vy += p.gravity;
+      p.vx *= 0.99;
+    } else {
+      p.vx *= 0.93; p.vy *= 0.93;
+    }
     p.life--;
     return p.life > 0;
   });
@@ -638,7 +874,13 @@ document.getElementById('nameInput').addEventListener('keydown', (e) => {
 
 document.getElementById('nextImg').src = TIERS[nextTier].img.src;
 
-window.addEventListener('pagehide', () => { if (!gameOver) saveState(); });
+window.addEventListener('pagehide', () => {
+  if (!gameOver) saveState();
+  if (sessionId) {
+    // keepalive lets the request survive the page going away
+    fetch(liveUrl(`/${sessionId}`), { method: 'DELETE', keepalive: true }).catch(() => {});
+  }
+});
 document.addEventListener('visibilitychange', () => {
   if (document.hidden && !gameOver) saveState();
 });

--- a/src/pages/coffee-merge/_app/game.js
+++ b/src/pages/coffee-merge/_app/game.js
@@ -107,15 +107,16 @@ const PB_URL = 'https://pb.bythe.rocks';
 const GAME_ID = 'coffee-merge';
 
 // Live ladder: each player upserts a row in `live_sessions` while playing,
-// and polls others' rows to fill the two flanking slots around their score.
+// subscribes to PocketBase realtime events for live_sessions and scores,
+// then fills two flanking slots around their score from the local cache.
 const LIVE_FRESH_MS = 30000;
 const LIVE_PATCH_INTERVAL_MS = 2000;
-const LIVE_POLL_INTERVAL_MS = 3000;
+const HEARTBEAT_INTERVAL_MS = 10000;
+const STALE_TICK_INTERVAL_MS = 5000;
 
 let sessionId = null;
-let liveTop = null;
-let liveAbove = null;
-let liveBelow = null;
+const liveSessionsMap = new Map();
+let topRecord = null;
 let prevWindowKeys = [];
 
 function liveUrl(suffix = '') {
@@ -175,19 +176,6 @@ async function deleteLiveSession() {
   } catch {}
 }
 
-async function fetchLiveRivals() {
-  // PocketBase filter wants "YYYY-MM-DD HH:MM:SS.sssZ" (space, not T).
-  const cutoff = new Date(Date.now() - LIVE_FRESH_MS).toISOString().replace('T', ' ');
-  let f = `game="${GAME_ID}" && updated>"${cutoff}"`;
-  if (sessionId) f += ` && id!="${sessionId}"`;
-  try {
-    const res = await fetch(liveUrl(`?filter=${encodeURIComponent(f)}&sort=-updated&perPage=20`));
-    if (!res.ok) return [];
-    const data = await res.json();
-    return data.items || [];
-  } catch { return []; }
-}
-
 async function fetchTopOne() {
   const f = encodeURIComponent(`game="${GAME_ID}"`);
   try {
@@ -198,52 +186,158 @@ async function fetchTopOne() {
   } catch { return null; }
 }
 
-let pollTimer = null;
-function startLivePolling() {
-  if (pollTimer) return;
-  pollLive();
-  pollTimer = setInterval(pollLive, LIVE_POLL_INTERVAL_MS);
-}
-function stopLivePolling() {
-  if (pollTimer) clearInterval(pollTimer);
-  pollTimer = null;
+async function bulkFetchLive() {
+  // PocketBase filter wants "YYYY-MM-DD HH:MM:SS.sssZ" (space, not T).
+  const cutoff = new Date(Date.now() - LIVE_FRESH_MS).toISOString().replace('T', ' ');
+  const f = encodeURIComponent(`game="${GAME_ID}" && updated>"${cutoff}"`);
+  try {
+    const res = await fetch(liveUrl(`?filter=${f}&sort=-updated&perPage=50`));
+    if (!res.ok) return;
+    const data = await res.json();
+    liveSessionsMap.clear();
+    for (const r of (data.items || [])) liveSessionsMap.set(r.id, r);
+  } catch {}
 }
 
-async function pollLive() {
-  // Heartbeat: bump our `updated` field even when no merge happened recently,
-  // so rivals don't see us go stale during long stretches of aiming.
-  scheduleLivePatch();
-  const [rivals, top] = await Promise.all([fetchLiveRivals(), fetchTopOne()]);
-  liveTop = top
-    ? { id: `top:${top.id}`, name: top.name, score: top.score, kind: 'top' }
-    : null;
-  liveAbove = null;
-  liveBelow = null;
-  for (const r of rivals) {
-    if (r.score > score) {
-      if (!liveAbove || r.score < liveAbove.score) {
-        liveAbove = { id: `live:${r.id}`, name: r.name, score: r.score, kind: 'live' };
-      }
-    } else if (r.score < score) {
-      if (!liveBelow || r.score > liveBelow.score) {
-        liveBelow = { id: `live:${r.id}`, name: r.name, score: r.score, kind: 'live' };
-      }
-    }
+let realtimeES = null;
+let realtimeClientId = null;
+async function subscribeRealtime() {
+  if (!realtimeClientId) return;
+  try {
+    await fetch(`${PB_URL}/api/realtime`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        clientId: realtimeClientId,
+        subscriptions: ['live_sessions', 'scores'],
+      }),
+    });
+  } catch (err) {
+    console.warn('realtime subscribe failed', err);
   }
-  renderLadder();
+}
+
+function startRealtime() {
+  if (realtimeES) return;
+  realtimeES = new EventSource(`${PB_URL}/api/realtime`);
+  realtimeES.addEventListener('PB_CONNECT', async (e) => {
+    try {
+      realtimeClientId = JSON.parse(e.data).clientId;
+      await subscribeRealtime();
+      const [, top] = await Promise.all([bulkFetchLive(), fetchTopOne()]);
+      topRecord = top;
+      renderLadder();
+    } catch (err) {
+      console.warn('realtime connect handler failed', err);
+    }
+  });
+  realtimeES.addEventListener('live_sessions', (e) => {
+    try {
+      const { action, record } = JSON.parse(e.data);
+      if (record.game !== GAME_ID) return;
+      if (action === 'delete') liveSessionsMap.delete(record.id);
+      else liveSessionsMap.set(record.id, record);
+      renderLadder();
+    } catch {}
+  });
+  realtimeES.addEventListener('scores', (e) => {
+    try {
+      const { record } = JSON.parse(e.data);
+      if (record.game !== GAME_ID) return;
+      // A new submission may be a new top — refetch the single top row.
+      fetchTopOne().then(t => { topRecord = t; renderLadder(); });
+    } catch {}
+  });
+  realtimeES.onerror = () => {
+    // EventSource auto-reconnects; PB_CONNECT will fire again with a fresh clientId.
+    console.warn('realtime connection error, will retry');
+  };
+}
+
+function stopRealtime() {
+  if (realtimeES) {
+    realtimeES.close();
+    realtimeES = null;
+  }
+  realtimeClientId = null;
+  liveSessionsMap.clear();
+  topRecord = null;
+}
+
+let heartbeatTimer = null;
+function startHeartbeat() {
+  if (heartbeatTimer) return;
+  // Bump our `updated` field on a steady cadence so we don't go stale in
+  // others' staleness filter during long stretches with no merges.
+  heartbeatTimer = setInterval(() => scheduleLivePatch(), HEARTBEAT_INTERVAL_MS);
+}
+function stopHeartbeat() {
+  if (heartbeatTimer) clearInterval(heartbeatTimer);
+  heartbeatTimer = null;
+}
+
+let staleTickTimer = null;
+function startStaleTick() {
+  if (staleTickTimer) return;
+  // Re-render periodically so rows that quietly went stale (e.g. a tab
+  // crashed without firing pagehide) drop out without waiting for an event.
+  staleTickTimer = setInterval(() => {
+    const pruneCutoff = Date.now() - LIVE_FRESH_MS * 2;
+    for (const [id, r] of liveSessionsMap) {
+      if (new Date(r.updated).getTime() < pruneCutoff) liveSessionsMap.delete(id);
+    }
+    renderLadder();
+  }, STALE_TICK_INTERVAL_MS);
+}
+function stopStaleTick() {
+  if (staleTickTimer) clearInterval(staleTickTimer);
+  staleTickTimer = null;
+}
+
+async function setupLiveLadder() {
+  await createLiveSession();
+  startRealtime();
+  startHeartbeat();
+  startStaleTick();
+}
+
+function teardownLiveLadder() {
+  stopHeartbeat();
+  stopStaleTick();
+  stopRealtime();
+  deleteLiveSession();
 }
 
 function computeLadderWindow() {
   const you = { id: 'you', name: 'YOU', score, kind: 'you' };
-  const candidates = [you];
+  const cutoff = Date.now() - LIVE_FRESH_MS;
+  let above = null, below = null;
+  for (const r of liveSessionsMap.values()) {
+    if (r.id === sessionId) continue;
+    if (new Date(r.updated).getTime() < cutoff) continue;
+    if (r.score > score) {
+      if (!above || r.score < above.score) above = r;
+    } else if (r.score < score) {
+      if (!below || r.score > below.score) below = r;
+    }
+  }
+  const aboveSlot = above
+    ? { id: `live:${above.id}`, name: above.name, score: above.score, kind: 'live' }
+    : null;
+  const belowSlot = below
+    ? { id: `live:${below.id}`, name: below.name, score: below.score, kind: 'live' }
+    : null;
   // Drop the top fallback if a live rival has the same name — the live row is more meaningful.
-  let topShow = liveTop;
-  if (topShow && (liveAbove?.name === topShow.name || liveBelow?.name === topShow.name)) {
+  let topShow = topRecord
+    ? { id: `top:${topRecord.id}`, name: topRecord.name, score: topRecord.score, kind: 'top' }
+    : null;
+  if (topShow && (aboveSlot?.name === topShow.name || belowSlot?.name === topShow.name)) {
     topShow = null;
   }
+  const candidates = [you];
   if (topShow) candidates.push(topShow);
-  if (liveAbove) candidates.push(liveAbove);
-  if (liveBelow) candidates.push(liveBelow);
+  if (aboveSlot) candidates.push(aboveSlot);
+  if (belowSlot) candidates.push(belowSlot);
   candidates.sort((a, b) => b.score - a.score);
   const yourIdx = candidates.findIndex(c => c.kind === 'you');
   const start = Math.max(0, yourIdx - 1);
@@ -269,10 +363,15 @@ function renderLadder() {
     li.dataset.id = c.id;
     const left = document.createElement('span');
     left.className = 'rung-name';
-    if (c.kind === 'live' || c.kind === 'top') {
+    if (c.kind === 'live') {
       const dot = document.createElement('span');
-      dot.className = `rung-status ${c.kind}`;
+      dot.className = 'rung-status live';
       left.appendChild(dot);
+    } else if (c.kind === 'top') {
+      const crown = document.createElement('span');
+      crown.className = 'rung-crown';
+      crown.textContent = '👑';
+      left.appendChild(crown);
     }
     left.appendChild(document.createTextNode(c.name || ''));
     const right = document.createElement('span');
@@ -500,10 +599,8 @@ function startGame() {
   clearState();
   startSaveTimer();
   prevWindowKeys = [];
-  liveAbove = liveBelow = liveTop = null;
   renderLadder();
-  createLiveSession();
-  startLivePolling();
+  setupLiveLadder();
 }
 
 function resumeGame(state) {
@@ -532,17 +629,14 @@ function resumeGame(state) {
   document.getElementById('gameover').classList.remove('show');
   startSaveTimer();
   prevWindowKeys = [];
-  liveAbove = liveBelow = liveTop = null;
   renderLadder();
-  createLiveSession();
-  startLivePolling();
+  setupLiveLadder();
 }
 
 function endGame() {
   gameOver = true;
   stopSaveTimer();
-  stopLivePolling();
-  deleteLiveSession();
+  teardownLiveLadder();
   clearState();
   document.getElementById('finalScore').textContent = score;
   const input = document.getElementById('nameInput');

--- a/src/pages/coffee-merge/_app/game.js
+++ b/src/pages/coffee-merge/_app/game.js
@@ -108,7 +108,7 @@ const GAME_ID = 'coffee-merge';
 
 // Live ladder: each player upserts a row in `live_sessions` while playing,
 // and polls others' rows to fill the two flanking slots around their score.
-const LIVE_FRESH_MS = 15000;
+const LIVE_FRESH_MS = 30000;
 const LIVE_PATCH_INTERVAL_MS = 2000;
 const LIVE_POLL_INTERVAL_MS = 3000;
 
@@ -180,7 +180,7 @@ async function fetchLiveRivals() {
   let f = `game="${GAME_ID}" && updated>"${cutoff}"`;
   if (sessionId) f += ` && id!="${sessionId}"`;
   try {
-    const res = await fetch(liveUrl(`?filter=${encodeURIComponent(f)}&perPage=20`));
+    const res = await fetch(liveUrl(`?filter=${encodeURIComponent(f)}&sort=-updated&perPage=20`));
     if (!res.ok) return [];
     const data = await res.json();
     return data.items || [];
@@ -209,6 +209,9 @@ function stopLivePolling() {
 }
 
 async function pollLive() {
+  // Heartbeat: bump our `updated` field even when no merge happened recently,
+  // so rivals don't see us go stale during long stretches of aiming.
+  scheduleLivePatch();
   const [rivals, top] = await Promise.all([fetchLiveRivals(), fetchTopOne()]);
   liveTop = top
     ? { id: `top:${top.id}`, name: top.name, score: top.score, kind: 'top' }

--- a/src/pages/coffee-merge/_app/game.js
+++ b/src/pages/coffee-merge/_app/game.js
@@ -223,10 +223,16 @@ function startRealtime() {
   realtimeES.addEventListener('PB_CONNECT', async (e) => {
     try {
       realtimeClientId = JSON.parse(e.data).clientId;
-      await subscribeRealtime();
+      // Bulk-fetch the starting state before subscribing — otherwise events
+      // arriving during the bulk fetch get wiped by its clear() call.
       const [, top] = await Promise.all([bulkFetchLive(), fetchTopOne()]);
       topRecord = top;
+      // Snap prevWindowKeys to the bulk state so the placeholder YOU-only
+      // ladder doesn't register as a "lineup change" on the first real
+      // render — otherwise the player's row pulses on every game start.
+      prevWindowKeys = computeLadderWindow().map(c => c.id);
       renderLadder();
+      await subscribeRealtime();
     } catch (err) {
       console.warn('realtime connect handler failed', err);
     }

--- a/src/pages/coffee-merge/_app/game.js
+++ b/src/pages/coffee-merge/_app/game.js
@@ -327,20 +327,22 @@ function computeLadderWindow() {
   const belowSlot = below
     ? { id: `live:${below.id}`, name: below.name, score: below.score, kind: 'live' }
     : null;
-  // Drop the top fallback if a live rival has the same name — the live row is more meaningful.
-  let topShow = topRecord
+  const topShow = topRecord
     ? { id: `top:${topRecord.id}`, name: topRecord.name, score: topRecord.score, kind: 'top' }
     : null;
-  if (topShow && (aboveSlot?.name === topShow.name || belowSlot?.name === topShow.name)) {
-    topShow = null;
-  }
   const candidates = [you];
   if (topShow) candidates.push(topShow);
   if (aboveSlot) candidates.push(aboveSlot);
   if (belowSlot) candidates.push(belowSlot);
-  candidates.sort((a, b) => b.score - a.score);
+  // On score ties, prefer top → live → you so the static TOP reference
+  // sits above the leader's matching live row when both are present.
+  const tieOrder = { top: 0, live: 1, you: 2 };
+  candidates.sort((a, b) => (b.score - a.score) || (tieOrder[a.kind] - tieOrder[b.kind]));
   const yourIdx = candidates.findIndex(c => c.kind === 'you');
-  const start = Math.max(0, yourIdx - 1);
+  // Start one above you, but slide the window up if we'd otherwise truncate
+  // (e.g. you're at the bottom of 3 candidates — without the slide, TOP at
+  // index 0 would fall outside the 3-row window).
+  const start = Math.max(0, Math.min(yourIdx - 1, candidates.length - 3));
   return candidates.slice(start, start + 3);
 }
 

--- a/src/pages/coffee-merge/_app/game.js
+++ b/src/pages/coffee-merge/_app/game.js
@@ -129,7 +129,7 @@ async function createLiveSession() {
     const res = await fetch(liveUrl(), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ game: GAME_ID, name: playerName, score: 0, tier: 0 }),
+      body: JSON.stringify({ game: GAME_ID, name: playerName, score, tier: maxTier }),
     });
     if (!res.ok) return;
     const data = await res.json();

--- a/src/pages/coffee-merge/_app/style.css
+++ b/src/pages/coffee-merge/_app/style.css
@@ -111,6 +111,23 @@ body.menu #stage { display: none; }
   background: rgba(255, 248, 220, 0.06);
   border: 1px solid rgba(255, 248, 220, 0.1);
 }
+#leaderboardList li.is-user {
+  background: rgba(255, 216, 155, 0.28);
+  border-color: rgba(255, 216, 155, 0.75);
+  box-shadow: 0 0 14px rgba(255, 216, 155, 0.25);
+}
+#leaderboardList li.separated {
+  margin-top: 22px;
+  position: relative;
+}
+#leaderboardList li.separated::before {
+  content: '⋮';
+  position: absolute;
+  top: -20px; left: 50%; transform: translateX(-50%);
+  color: rgba(255, 248, 220, 0.5);
+  font-size: 18px;
+  line-height: 1;
+}
 #leaderboardList li .rank {
   min-width: 32px;
   font-size: 16px; font-weight: 700;

--- a/src/pages/coffee-merge/_app/style.css
+++ b/src/pages/coffee-merge/_app/style.css
@@ -81,8 +81,9 @@ canvas {
   box-shadow: 0 0 6px #4ade80;
   animation: liveDot 1.6s ease-in-out infinite;
 }
-.rung-status.top {
-  background: #ffd89b;
+.rung-crown {
+  font-size: 13px;
+  line-height: 1;
 }
 @keyframes liveDot {
   0%, 100% { box-shadow: 0 0 4px #4ade80; }

--- a/src/pages/coffee-merge/_app/style.css
+++ b/src/pages/coffee-merge/_app/style.css
@@ -41,17 +41,66 @@ canvas {
   color: #fff8e7; font-weight: 700;
   text-shadow: 0 2px 4px rgba(60, 20, 0, 0.6);
 }
-#score {
+#ladder {
   flex: 1;
-  display: flex; align-items: center; justify-content: space-between;
-  color: #fff8e7; font-weight: 700;
+  list-style: none; margin: 0;
+  display: flex; flex-direction: column; justify-content: center;
+  gap: 1px;
+  color: #fff8e7;
   text-shadow: 0 2px 4px rgba(60, 20, 0, 0.6);
-  font-size: 15px; letter-spacing: 0.08em; text-transform: uppercase;
   background: linear-gradient(180deg, #b8895a, #8d6238);
-  padding: 12px 22px; border-radius: 16px;
+  padding: 8px 18px; border-radius: 16px;
   box-shadow: 0 0 0 4px #4a2c14, 0 0 0 7px #c98a52, 0 6px 14px rgba(0,0,0,0.25);
+  overflow: hidden;
+  min-width: 0;
 }
-#score b { font-size: 28px; letter-spacing: 0; color: #ffd89b; }
+.rung {
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: 10px;
+  font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
+  font-size: 11px; opacity: 0.55;
+  transition: transform 0.3s ease, opacity 0.3s ease, font-size 0.3s ease;
+  min-width: 0;
+}
+.rung-name {
+  display: flex; align-items: center; gap: 6px; min-width: 0;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.rung-score {
+  color: rgba(255, 248, 220, 0.55);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+.rung-status {
+  display: inline-block; width: 6px; height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.rung-status.live {
+  background: #4ade80;
+  box-shadow: 0 0 6px #4ade80;
+  animation: liveDot 1.6s ease-in-out infinite;
+}
+.rung-status.top {
+  background: #ffd89b;
+}
+@keyframes liveDot {
+  0%, 100% { box-shadow: 0 0 4px #4ade80; }
+  50%      { box-shadow: 0 0 10px #4ade80; opacity: 0.8; }
+}
+.rung.is-you {
+  font-size: 22px;
+  opacity: 1;
+}
+.rung.is-you .rung-score { color: #ffd89b; }
+.rung.pulse {
+  animation: rungPulse 600ms ease;
+}
+@keyframes rungPulse {
+  0%   { transform: scale(1);    filter: drop-shadow(0 0 0 transparent); }
+  35%  { transform: scale(1.06); filter: drop-shadow(0 0 8px rgba(255, 216, 155, 0.9)); }
+  100% { transform: scale(1);    filter: drop-shadow(0 0 0 transparent); }
+}
 #next {
   width: 78px; height: 78px;
   color: #fff8e7; font-weight: 700;

--- a/src/pages/coffee-merge/index.astro
+++ b/src/pages/coffee-merge/index.astro
@@ -18,7 +18,7 @@
   </div>
   <div id="stage">
     <div id="hud-top">
-      <div id="score">Score<b id="scoreVal">0</b></div>
+      <ol id="ladder"></ol>
       <div id="next">
         <img id="nextImg" alt="" />
         <span class="label">next</span>


### PR DESCRIPTION
Each player now appears at most once (their best run). The leaderboard
shows the top 5 players, plus the current player's row (highlighted, with
their actual rank) when they fall outside the top 5.