### PR TITLE
scoreboard: add landscape scoreboard with match timer

### DIFF
--- a/src/content/works/scoreboard.json
+++ b/src/content/works/scoreboard.json
@@ -1,0 +1,12 @@
+{
+  "title": "Scoreboard",
+  "stage": "scribble",
+  "date": "2026-05-16",
+  "description": "Two-tap landscape scoreboard with a match timer. Tap a side to add, swipe down to subtract; hold the timer pill to reset. Settings for count-up/down, increment, buzzer, haptics, and screen-wake.",
+  "tags": [
+    "tool",
+    "sports"
+  ],
+  "category": "fun",
+  "icon": "trophy"
+}

--- a/src/pages/scoreboard/_app/app.css
+++ b/src/pages/scoreboard/_app/app.css
@@ -432,58 +432,49 @@ html, body {
 }
 .sb-btn-danger:hover { background: rgba(229, 90, 90, 0.08); }
 
-/* ---- Rotate prompt for portrait mobile ---- */
-.rotate-warning {
-  display: none;
-  position: fixed;
-  inset: 0;
-  background: var(--sb-ink);
-  color: var(--sb-cream);
+/* ---- Floating fullscreen button ---- */
+.fs-btn {
+  position: absolute;
+  top: 2.2vh;
+  right: 2.2vh;
+  width: 36px;
+  height: 36px;
+  display: flex;
   align-items: center;
   justify-content: center;
-  flex-direction: column;
-  gap: 24px;
-  z-index: 200;
-  text-align: center;
-  padding: 30px;
-}
-
-@media (orientation: portrait) and (max-height: 900px) {
-  .rotate-warning { display: flex; }
-}
-
-.phone-icon {
-  width: 56px;
-  height: 96px;
-  border: 3px solid var(--sb-cream);
+  background: rgba(255, 255, 255, 0.14);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  border: none;
   border-radius: 10px;
-  position: relative;
-  animation: sb-spin 2.4s ease-in-out infinite;
+  color: rgba(255, 255, 255, 0.78);
+  cursor: pointer;
+  z-index: 10;
+  padding: 0;
+  transition: background 0.15s ease, color 0.15s ease, transform 0.12s ease;
 }
-.phone-icon::after {
-  content: '';
-  position: absolute;
-  bottom: 6px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 18px;
-  height: 3px;
-  background: var(--sb-cream);
-  border-radius: 2px;
-}
-@keyframes sb-spin {
-  0%, 35% { transform: rotate(0); }
-  65%, 100% { transform: rotate(-90deg); }
-}
+.fs-btn:hover { background: rgba(255, 255, 255, 0.22); color: white; }
+.fs-btn:active { transform: scale(0.94); }
 
-.rotate-warning h1 {
-  font-family: 'Big Shoulders Display', sans-serif;
-  font-weight: 800;
-  font-size: 28px;
-  letter-spacing: 0.02em;
-}
-.rotate-warning p {
-  opacity: 0.7;
-  font-size: 14px;
-  max-width: 280px;
+/* ---- Portrait: stack the two halves vertically ---- */
+@media (orientation: portrait) {
+  .scoreboard { flex-direction: column; }
+
+  .score { font-size: clamp(110px, min(34vh, 26vw), 320px); }
+
+  /* Re-centre labels/hints horizontally inside each stacked half */
+  .side .label,
+  .side .hint {
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+    text-align: center;
+  }
+  .side.left .label,
+  .side.right .label { bottom: 3vh; }
+  .side.left .hint,
+  .side.right .hint { bottom: 1vh; font-size: 9px; }
+
+  /* Keep the fullscreen button clear of the timer pill at top-centre */
+  .fs-btn { top: 2.2vh; right: 2.2vh; }
 }

--- a/src/pages/scoreboard/_app/app.css
+++ b/src/pages/scoreboard/_app/app.css
@@ -1,0 +1,489 @@
+/* Scoreboard — scoped to .scoreboard wrapper to avoid leaking onto AppLayout chrome */
+
+:root {
+  --sb-left: #4F65E5;
+  --sb-left-deep: #3D52D4;
+  --sb-right: #E55A5A;
+  --sb-right-deep: #D44848;
+  --sb-cream: #FAF5E6;
+  --sb-ink: #1E1E22;
+  --sb-shadow: 0 10px 40px rgba(0, 0, 0, 0.18);
+}
+
+html, body {
+  overflow: hidden;
+  overscroll-behavior: none;
+  touch-action: none;
+}
+
+.scoreboard, .scoreboard * {
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.scoreboard {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100dvh;
+  display: flex;
+  background: var(--sb-ink);
+  font-family: 'Bricolage Grotesque', system-ui, sans-serif;
+  overflow: hidden;
+  touch-action: none;
+  z-index: 1;
+}
+
+/* ---- The two halves ---- */
+.side {
+  flex: 1;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  touch-action: none;
+  cursor: pointer;
+  transition: filter 0.2s ease;
+}
+
+.side.left {
+  background:
+    radial-gradient(ellipse at 30% 20%, rgba(255,255,255,0.08), transparent 60%),
+    linear-gradient(155deg, var(--sb-left) 0%, var(--sb-left-deep) 100%);
+}
+
+.side.right {
+  background:
+    radial-gradient(ellipse at 70% 80%, rgba(255,255,255,0.08), transparent 60%),
+    linear-gradient(205deg, var(--sb-right) 0%, var(--sb-right-deep) 100%);
+}
+
+.side:active { filter: brightness(0.96); }
+
+/* The big numbers */
+.score {
+  font-family: 'Big Shoulders Display', sans-serif;
+  font-weight: 900;
+  font-size: clamp(180px, 42vh, 460px);
+  color: var(--sb-cream);
+  line-height: 0.82;
+  text-shadow: 0 6px 24px rgba(0, 0, 0, 0.18);
+  font-feature-settings: "tnum" 1;
+  transition: transform 0.22s cubic-bezier(0.34, 1.56, 0.64, 1),
+              color 0.2s ease;
+  pointer-events: none;
+  will-change: transform;
+}
+
+.score.bump { transform: scale(1.14); }
+.score.dip { transform: scale(0.86); color: rgba(250, 245, 230, 0.7); }
+
+/* Side labels */
+.label {
+  position: absolute;
+  bottom: 4vh;
+  font-size: 11px;
+  letter-spacing: 0.42em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: 600;
+  pointer-events: none;
+}
+.side.left .label { left: 5vh; }
+.side.right .label { right: 5vh; }
+
+/* Hint at bottom */
+.hint {
+  position: absolute;
+  bottom: 4vh;
+  font-size: 10px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.35);
+  font-weight: 500;
+  pointer-events: none;
+  transition: opacity 0.6s ease;
+}
+.side.left .hint { right: 5vh; }
+.side.right .hint { left: 5vh; }
+.hint.gone { opacity: 0; }
+
+/* Ripple feedback */
+.ripple {
+  position: absolute;
+  border-radius: 50%;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+  background: radial-gradient(circle, rgba(255,255,255,0.35) 0%, rgba(255,255,255,0) 70%);
+  animation: sb-ripple 0.55s ease-out forwards;
+}
+@keyframes sb-ripple {
+  from { width: 0; height: 0; opacity: 1; }
+  to { width: 360px; height: 360px; opacity: 0; }
+}
+
+/* ---- Timer pill ---- */
+.timer-pill {
+  position: absolute;
+  top: 2.2vh;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--sb-cream);
+  padding: 10px 16px 10px 14px;
+  border-radius: 18px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  box-shadow: var(--sb-shadow), 0 1px 0 rgba(255,255,255,0.6) inset;
+  cursor: pointer;
+  z-index: 10;
+  user-select: none;
+  transition: background 0.3s ease, transform 0.12s ease;
+  will-change: transform;
+}
+.timer-pill:active { transform: translateX(-50%) scale(0.97); }
+
+.timer-pill.paused { background: #F5E6BD; }
+
+.timer-pill.warning {
+  background: #FFD0CC;
+  animation: sb-warn 0.9s ease-in-out infinite;
+}
+@keyframes sb-warn {
+  0%, 100% { transform: translateX(-50%) scale(1); }
+  50% { transform: translateX(-50%) scale(1.04); }
+}
+
+/* Hold-to-reset progress ring */
+.hold-ring {
+  position: absolute;
+  inset: -3px;
+  border-radius: 21px;
+  border: 2.5px solid transparent;
+  pointer-events: none;
+  transition: border-color 0.1s ease;
+}
+.timer-pill.holding .hold-ring {
+  border-color: var(--sb-ink);
+  animation: sb-hold-fill 0.6s linear forwards;
+}
+@keyframes sb-hold-fill {
+  from { clip-path: polygon(50% 0%, 50% 0%, 50% 0%, 50% 0%, 50% 0%); }
+  to   { clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%, 0% 0%); }
+}
+
+.timer-icon {
+  width: 18px;
+  height: 18px;
+  color: #8A857A;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.timer-icon.btn {
+  cursor: pointer;
+  padding: 4px;
+  margin: -4px;
+  box-sizing: content-box;
+  border-radius: 8px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.timer-icon.btn:hover { background: rgba(0,0,0,0.06); color: var(--sb-ink); }
+.timer-icon.btn:active { background: rgba(0,0,0,0.12); }
+
+.timer-text {
+  font-family: 'Big Shoulders Display', sans-serif;
+  font-weight: 800;
+  font-size: clamp(28px, 4.5vh, 40px);
+  color: var(--sb-ink);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+  line-height: 1;
+  min-width: 2.6em;
+  text-align: center;
+}
+
+.timer-pill.warning .timer-text { color: #B22F2F; }
+
+/* Status badge below the timer pill (PAUSED / TIME) */
+.timer-badge {
+  position: absolute;
+  top: calc(2.2vh + 70px);
+  left: 50%;
+  transform: translateX(-50%) translateY(-6px);
+  background: rgba(15, 15, 20, 0.55);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  color: var(--sb-cream);
+  font-family: 'Bricolage Grotesque', sans-serif;
+  font-weight: 700;
+  font-size: 10.5px;
+  letter-spacing: 0.32em;
+  padding: 5px 12px 4px;
+  border-radius: 10px;
+  z-index: 9;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.timer-badge.show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+.timer-badge.done {
+  background: rgba(180, 30, 30, 0.85);
+  animation: sb-badge-flash 0.6s ease-in-out infinite alternate;
+}
+@keyframes sb-badge-flash {
+  from { opacity: 0.7; }
+  to { opacity: 1; }
+}
+
+/* ---- Settings modal ---- */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 15, 20, 0.55);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 20px;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+.modal-backdrop.show {
+  display: flex;
+  opacity: 1;
+}
+
+.modal {
+  background: var(--sb-cream);
+  border-radius: 24px;
+  padding: 28px 26px 22px;
+  width: min(92vw, 440px);
+  max-height: 92vh;
+  overflow-y: auto;
+  box-shadow: 0 30px 80px rgba(0,0,0,0.4);
+  transform: translateY(8px) scale(0.98);
+  transition: transform 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.modal-backdrop.show .modal { transform: translateY(0) scale(1); }
+
+.modal h2 {
+  font-family: 'Big Shoulders Display', sans-serif;
+  font-weight: 800;
+  font-size: 32px;
+  letter-spacing: 0.01em;
+  color: var(--sb-ink);
+  margin-bottom: 4px;
+}
+.modal .sub {
+  font-size: 12px;
+  color: #8A857A;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  margin-bottom: 18px;
+  font-weight: 600;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 0;
+  border-top: 1px solid rgba(30, 30, 34, 0.08);
+}
+.row:first-of-type { border-top: none; }
+
+.row label {
+  font-size: 15px;
+  color: var(--sb-ink);
+  font-weight: 500;
+}
+
+.time-input {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  font-family: 'Big Shoulders Display', sans-serif;
+  font-weight: 700;
+  font-size: 22px;
+}
+.time-input input {
+  width: 56px;
+  padding: 8px 4px;
+  border: 1.5px solid rgba(30, 30, 34, 0.12);
+  border-radius: 10px;
+  font: inherit;
+  text-align: center;
+  background: white;
+  color: var(--sb-ink);
+  transition: border-color 0.15s ease;
+}
+.time-input input:focus {
+  outline: none;
+  border-color: var(--sb-left);
+}
+.time-input span { color: #8A857A; }
+
+.inc-pick, .mode-pick {
+  display: flex;
+  gap: 6px;
+}
+.inc-pick button, .mode-pick button {
+  border: 1.5px solid rgba(30, 30, 34, 0.12);
+  background: white;
+  border-radius: 10px;
+  font: inherit;
+  color: var(--sb-ink);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.inc-pick button {
+  width: 38px;
+  height: 38px;
+  font-weight: 700;
+}
+.mode-pick button {
+  padding: 8px 14px;
+  height: 38px;
+  font-weight: 600;
+  font-size: 13px;
+  white-space: nowrap;
+}
+.inc-pick button.on, .mode-pick button.on {
+  background: var(--sb-ink);
+  color: var(--sb-cream);
+  border-color: var(--sb-ink);
+}
+
+.toggle {
+  position: relative;
+  width: 46px;
+  height: 26px;
+  background: rgba(30, 30, 34, 0.18);
+  border-radius: 14px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  flex-shrink: 0;
+}
+.toggle::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
+  background: white;
+  border-radius: 50%;
+  transition: left 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.15);
+}
+.toggle.on { background: var(--sb-left); }
+.toggle.on::after { left: 23px; }
+
+.actions {
+  margin-top: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sb-btn {
+  display: block;
+  width: 100%;
+  padding: 13px;
+  border-radius: 12px;
+  border: none;
+  font-family: 'Bricolage Grotesque', sans-serif;
+  font-weight: 600;
+  font-size: 14.5px;
+  cursor: pointer;
+  letter-spacing: 0.02em;
+  text-align: center;
+  text-decoration: none;
+  transition: transform 0.1s ease, background 0.15s ease;
+}
+.sb-btn:active { transform: scale(0.98); }
+.sb-btn-primary {
+  background: var(--sb-ink);
+  color: var(--sb-cream);
+}
+.sb-btn-primary:hover { background: #2a2a30; }
+.sb-btn-ghost {
+  background: transparent;
+  color: var(--sb-ink);
+  border: 1.5px solid rgba(30, 30, 34, 0.15);
+}
+.sb-btn-ghost:hover { background: rgba(30, 30, 34, 0.04); }
+.sb-btn-danger {
+  background: transparent;
+  color: var(--sb-right-deep);
+  border: 1.5px solid rgba(217, 72, 72, 0.3);
+}
+.sb-btn-danger:hover { background: rgba(229, 90, 90, 0.08); }
+
+/* ---- Rotate prompt for portrait mobile ---- */
+.rotate-warning {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: var(--sb-ink);
+  color: var(--sb-cream);
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 24px;
+  z-index: 200;
+  text-align: center;
+  padding: 30px;
+}
+
+@media (orientation: portrait) and (max-height: 900px) {
+  .rotate-warning { display: flex; }
+}
+
+.phone-icon {
+  width: 56px;
+  height: 96px;
+  border: 3px solid var(--sb-cream);
+  border-radius: 10px;
+  position: relative;
+  animation: sb-spin 2.4s ease-in-out infinite;
+}
+.phone-icon::after {
+  content: '';
+  position: absolute;
+  bottom: 6px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 18px;
+  height: 3px;
+  background: var(--sb-cream);
+  border-radius: 2px;
+}
+@keyframes sb-spin {
+  0%, 35% { transform: rotate(0); }
+  65%, 100% { transform: rotate(-90deg); }
+}
+
+.rotate-warning h1 {
+  font-family: 'Big Shoulders Display', sans-serif;
+  font-weight: 800;
+  font-size: 28px;
+  letter-spacing: 0.02em;
+}
+.rotate-warning p {
+  opacity: 0.7;
+  font-size: 14px;
+  max-width: 280px;
+}

--- a/src/pages/scoreboard/_app/app.css
+++ b/src/pages/scoreboard/_app/app.css
@@ -240,6 +240,11 @@ html, body {
   background: rgba(180, 30, 30, 0.85);
   animation: sb-badge-flash 0.6s ease-in-out infinite alternate;
 }
+/* Persistent mode badge sits quieter than the temporary PAUSED/TIME states */
+.timer-badge.mode {
+  background: rgba(15, 15, 20, 0.32);
+  color: rgba(250, 245, 230, 0.78);
+}
 @keyframes sb-badge-flash {
   from { opacity: 0.7; }
   to { opacity: 1; }

--- a/src/pages/scoreboard/_app/app.jsx
+++ b/src/pages/scoreboard/_app/app.jsx
@@ -27,6 +27,33 @@ const SettingsIcon = () => (
     <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
   </svg>
 );
+const EnterFullscreenIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="18" height="18">
+    <path d="M3 9V3h6M21 9V3h-6M3 15v6h6M21 15v6h-6" />
+  </svg>
+);
+const ExitFullscreenIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="18" height="18">
+    <path d="M9 3v6H3M15 3v6h6M9 21v-6H3M15 21v-6h6" />
+  </svg>
+);
+
+const isFullscreenSupported = () =>
+  typeof document !== 'undefined' &&
+  (document.fullscreenEnabled || document.webkitFullscreenEnabled);
+
+const getFullscreenElement = () =>
+  document.fullscreenElement || document.webkitFullscreenElement || null;
+
+const requestFullscreen = (el) => {
+  const fn = el.requestFullscreen || el.webkitRequestFullscreen;
+  return fn ? fn.call(el) : Promise.reject();
+};
+
+const exitFullscreen = () => {
+  const fn = document.exitFullscreen || document.webkitExitFullscreen;
+  return fn ? fn.call(document) : Promise.reject();
+};
 
 const vibe = (enabled, pattern) => {
   if (enabled && typeof navigator !== 'undefined' && navigator.vibrate) {
@@ -129,6 +156,8 @@ export function App() {
   const [modalOpen, setModalOpen] = useState(false);
   const [hintGone, setHintGone] = useState(false);
   const [holding, setHolding] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [fullscreenAvailable, setFullscreenAvailable] = useState(false);
 
   // Draft inputs while the settings modal is open
   const [draftMins, setDraftMins] = useState(Math.floor(timerDuration / 60));
@@ -142,6 +171,12 @@ export function App() {
   const wakeLockRef = useRef(null);
   const holdTimeoutRef = useRef(null);
   const didHoldRef = useRef(false);
+
+  // Wall-clock timer state. Time elapsed is derived from these refs on every
+  // tick, so even if the browser throttles the interval (background tab,
+  // device sleep) the displayed value stays correct on resume.
+  const anchorRef = useRef(null);      // ms timestamp when the current segment started; null while paused
+  const accumulatedRef = useRef(0);    // ms elapsed during previously-finished segments
 
   const finished = mode === 'down' ? timerValue <= 0 : timerValue >= timerDuration;
   const idle = !timerRunning && timerValue === startValue;
@@ -163,6 +198,27 @@ export function App() {
       window.removeEventListener('keydown', unlock, true);
     };
   }, []);
+
+  // ---- Fullscreen ----
+  useEffect(() => {
+    setFullscreenAvailable(isFullscreenSupported());
+    const onChange = () => setIsFullscreen(!!getFullscreenElement());
+    document.addEventListener('fullscreenchange', onChange);
+    document.addEventListener('webkitfullscreenchange', onChange);
+    onChange(); // sync initial state
+    return () => {
+      document.removeEventListener('fullscreenchange', onChange);
+      document.removeEventListener('webkitfullscreenchange', onChange);
+    };
+  }, []);
+
+  const toggleFullscreen = async (e) => {
+    e?.stopPropagation();
+    try {
+      if (getFullscreenElement()) await exitFullscreen();
+      else await requestFullscreen(document.documentElement);
+    } catch { /* silently degrade — e.g. iPhone Safari */ }
+  };
 
   // ---- Wake lock ----
   const requestWakeLock = useCallback(async () => {
@@ -190,31 +246,45 @@ export function App() {
     return () => document.removeEventListener('visibilitychange', onVisibility);
   }, [requestWakeLock]);
 
-  // ---- Timer tick ----
+  // ---- Timer tick (wall-clock based) ----
+  // The displayed value is computed from anchorRef + accumulatedRef rather
+  // than decremented each second, so backgrounded/throttled tabs catch up
+  // correctly on the next tick.
   useEffect(() => {
     if (!timerRunning) return;
-    const id = setInterval(() => {
-      setTimerValue(v => {
-        const s = settingsRef.current;
-        const next = s.mode === 'down' ? v - 1 : v + 1;
-        const isFinished = s.mode === 'down' ? next <= 0 : next >= s.timerDuration;
-        if (isFinished) {
-          const snap = s.mode === 'down' ? 0 : s.timerDuration;
-          // Defer the running-state flip so we don't update state mid-render
-          setTimeout(() => setTimerRunning(false), 0);
-          if (s.mode === 'down') {
-            buzzer(s.sound);
-            vibe(s.haptics, [240, 100, 240, 100, 480]);
-          } else {
-            vibe(s.haptics, [180, 80, 180, 80, 320]);
-          }
-          return snap;
+    let prev = -1;
+    const tick = () => {
+      const s = settingsRef.current;
+      const elapsedMs = accumulatedRef.current
+        + (anchorRef.current != null ? Date.now() - anchorRef.current : 0);
+      const elapsedSec = Math.floor(elapsedMs / 1000);
+      const next = s.mode === 'down'
+        ? Math.max(0, s.timerDuration - elapsedSec)
+        : Math.min(s.timerDuration, elapsedSec);
+      if (next === prev) return;
+      prev = next;
+      const isFinished = s.mode === 'down' ? next <= 0 : next >= s.timerDuration;
+      if (isFinished) {
+        // Lock state at the finish line so timerValue stays at the end value
+        anchorRef.current = null;
+        accumulatedRef.current = s.timerDuration * 1000;
+        setTimerValue(s.mode === 'down' ? 0 : s.timerDuration);
+        setTimerRunning(false);
+        if (s.mode === 'down') {
+          buzzer(s.sound);
+          vibe(s.haptics, [240, 100, 240, 100, 480]);
+        } else {
+          vibe(s.haptics, [180, 80, 180, 80, 320]);
         }
-        const leftSec = s.mode === 'down' ? next : s.timerDuration - next;
-        if (leftSec > 0 && leftSec <= 5) vibe(s.haptics, 35);
-        return next;
-      });
-    }, 1000);
+        return;
+      }
+      setTimerValue(next);
+      const leftSec = s.mode === 'down' ? next : s.timerDuration - next;
+      if (leftSec > 0 && leftSec <= 5) vibe(s.haptics, 35);
+    };
+    tick();
+    // Sub-second polling so we catch up quickly when the tab is foregrounded.
+    const id = setInterval(tick, 250);
     return () => clearInterval(id);
   }, [timerRunning]);
 
@@ -239,10 +309,19 @@ export function App() {
   const startTimer = () => {
     if (timerRunning || finished) return;
     ensureAudio();
+    anchorRef.current = Date.now();
     setTimerRunning(true);
   };
-  const stopTimer = () => setTimerRunning(false);
+  const stopTimer = () => {
+    if (anchorRef.current != null) {
+      accumulatedRef.current += Date.now() - anchorRef.current;
+      anchorRef.current = null;
+    }
+    setTimerRunning(false);
+  };
   const resetTimer = () => {
+    anchorRef.current = null;
+    accumulatedRef.current = 0;
     setTimerRunning(false);
     setTimerValue(mode === 'down' ? timerDuration : 0);
     vibe(haptics, [30, 30, 30]);
@@ -286,6 +365,8 @@ export function App() {
     const durationChanged = total !== timerDuration;
     setTimerDuration(total);
     if (!timerRunning && (durationChanged || idle || finished)) {
+      anchorRef.current = null;
+      accumulatedRef.current = 0;
       setTimerValue(mode === 'down' ? total : 0);
     }
     setModalOpen(false);
@@ -294,6 +375,8 @@ export function App() {
   const changeMode = (newMode) => {
     if (newMode === mode) return;
     setMode(newMode);
+    anchorRef.current = null;
+    accumulatedRef.current = 0;
     setTimerRunning(false);
     setTimerValue(newMode === 'down' ? timerDuration : 0);
   };
@@ -325,6 +408,8 @@ export function App() {
   const resetEverything = () => {
     setScoreLeft(0);
     setScoreRight(0);
+    anchorRef.current = null;
+    accumulatedRef.current = 0;
     setTimerRunning(false);
     setTimerValue(mode === 'down' ? timerDuration : 0);
     vibe(haptics, [40, 60, 40]);
@@ -400,11 +485,16 @@ export function App() {
           {finished ? 'TIME' : 'PAUSED'}
         </div>
 
-        <div className="rotate-warning">
-          <div className="phone-icon" />
-          <h1>Rotate to landscape</h1>
-          <p>This scoreboard is designed for landscape orientation.</p>
-        </div>
+        {fullscreenAvailable && (
+          <button
+            type="button"
+            className="fs-btn"
+            aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+            onClick={toggleFullscreen}
+          >
+            {isFullscreen ? <ExitFullscreenIcon /> : <EnterFullscreenIcon />}
+          </button>
+        )}
       </div>
 
       <div

--- a/src/pages/scoreboard/_app/app.jsx
+++ b/src/pages/scoreboard/_app/app.jsx
@@ -173,11 +173,14 @@ export function App() {
   const anchorRef = useRef(null);      // ms timestamp when the current segment started; null while paused
   const accumulatedRef = useRef(0);    // ms elapsed during previously-finished segments
 
-  const finished = mode === 'down' ? timerValue <= 0 : timerValue >= timerDuration;
+  // Stopwatch ('up') has no target — it just counts up; we cap at 99:59
+  // (5999 s) so the MM:SS display can't overflow.
+  const STOPWATCH_CAP = 99 * 60 + 59;
+
+  const finished = mode === 'down' && timerValue <= 0;
   const idle = !timerRunning && timerValue === startValue;
   const paused = !timerRunning && !idle && !finished;
-  const left = mode === 'down' ? timerValue : timerDuration - timerValue;
-  const warning = !finished && left > 0 && left <= 10;
+  const warning = mode === 'down' && !finished && timerValue > 0 && timerValue <= 10;
 
   // ---- Audio unlock on first user gesture anywhere ----
   useEffect(() => {
@@ -254,27 +257,30 @@ export function App() {
       const elapsedSec = Math.floor(elapsedMs / 1000);
       const next = s.mode === 'down'
         ? Math.max(0, s.timerDuration - elapsedSec)
-        : Math.min(s.timerDuration, elapsedSec);
+        : Math.min(STOPWATCH_CAP, elapsedSec);
       if (next === prev) return;
       prev = next;
-      const isFinished = s.mode === 'down' ? next <= 0 : next >= s.timerDuration;
-      if (isFinished) {
-        // Lock state at the finish line so timerValue stays at the end value
+      if (s.mode === 'down' && next <= 0) {
+        // Countdown finished — buzzer + final haptic, lock state at zero.
         anchorRef.current = null;
         accumulatedRef.current = s.timerDuration * 1000;
-        setTimerValue(s.mode === 'down' ? 0 : s.timerDuration);
+        setTimerValue(0);
         setTimerRunning(false);
-        if (s.mode === 'down') {
-          buzzer(s.sound);
-          vibe(s.haptics, [240, 100, 240, 100, 480]);
-        } else {
-          vibe(s.haptics, [180, 80, 180, 80, 320]);
-        }
+        buzzer(s.sound);
+        vibe(s.haptics, [240, 100, 240, 100, 480]);
+        return;
+      }
+      if (s.mode === 'up' && next >= STOPWATCH_CAP) {
+        // Stopwatch reached the display cap — stop silently.
+        anchorRef.current = null;
+        accumulatedRef.current = STOPWATCH_CAP * 1000;
+        setTimerValue(STOPWATCH_CAP);
+        setTimerRunning(false);
         return;
       }
       setTimerValue(next);
-      const leftSec = s.mode === 'down' ? next : s.timerDuration - next;
-      if (leftSec > 0 && leftSec <= 5) vibe(s.haptics, 35);
+      // 5-second warning tick — countdown only
+      if (s.mode === 'down' && next > 0 && next <= 5) vibe(s.haptics, 35);
     };
     tick();
     // Sub-second polling so we catch up quickly when the tab is foregrounded.
@@ -472,11 +478,13 @@ export function App() {
 
         <div
           className={[
-            'timer-badge',
-            finished ? 'show done' : paused ? 'show' : '',
+            'timer-badge show',
+            finished ? 'done' : '',
+            paused ? 'paused' : '',
+            !finished && !paused ? 'mode' : '',
           ].filter(Boolean).join(' ')}
         >
-          {finished ? 'TIME' : 'PAUSED'}
+          {finished ? 'TIME' : paused ? 'PAUSED' : (mode === 'down' ? 'MATCH' : 'STOPWATCH')}
         </div>
 
         <button
@@ -498,41 +506,43 @@ export function App() {
           <div className="sub">Settings</div>
 
           <div className="row">
-            <label>Match length</label>
-            <div className="time-input">
-              <input
-                type="number"
-                min="0"
-                max="99"
-                value={draftMins}
-                inputMode="numeric"
-                onChange={(e) => setDraftMins(e.target.value)}
-              />
-              <span>:</span>
-              <input
-                type="number"
-                min="0"
-                max="59"
-                value={draftSecs}
-                inputMode="numeric"
-                onChange={(e) => setDraftSecs(e.target.value)}
-              />
-            </div>
-          </div>
-
-          <div className="row">
             <label>Timer mode</label>
             <div className="mode-pick">
               <button
                 className={mode === 'down' ? 'on' : ''}
                 onClick={() => changeMode('down')}
-              >Count down</button>
+              >Match timer</button>
               <button
                 className={mode === 'up' ? 'on' : ''}
                 onClick={() => changeMode('up')}
-              >Count up</button>
+              >Stopwatch</button>
             </div>
           </div>
+
+          {mode === 'down' && (
+            <div className="row">
+              <label>Match length</label>
+              <div className="time-input">
+                <input
+                  type="number"
+                  min="0"
+                  max="99"
+                  value={draftMins}
+                  inputMode="numeric"
+                  onChange={(e) => setDraftMins(e.target.value)}
+                />
+                <span>:</span>
+                <input
+                  type="number"
+                  min="0"
+                  max="59"
+                  value={draftSecs}
+                  inputMode="numeric"
+                  onChange={(e) => setDraftSecs(e.target.value)}
+                />
+              </div>
+            </div>
+          )}
 
           <div className="row">
             <label>Point increment</label>
@@ -547,15 +557,17 @@ export function App() {
             </div>
           </div>
 
-          <div className="row">
-            <label>Buzzer at full time</label>
-            <div
-              className={`toggle${sound ? ' on' : ''}`}
-              role="switch"
-              aria-checked={sound}
-              onClick={toggleSound}
-            />
-          </div>
+          {mode === 'down' && (
+            <div className="row">
+              <label>Buzzer at full time</label>
+              <div
+                className={`toggle${sound ? ' on' : ''}`}
+                role="switch"
+                aria-checked={sound}
+                onClick={toggleSound}
+              />
+            </div>
+          )}
 
           <div className="row">
             <label>Haptic feedback</label>

--- a/src/pages/scoreboard/_app/app.jsx
+++ b/src/pages/scoreboard/_app/app.jsx
@@ -38,10 +38,6 @@ const ExitFullscreenIcon = () => (
   </svg>
 );
 
-const isFullscreenSupported = () =>
-  typeof document !== 'undefined' &&
-  (document.fullscreenEnabled || document.webkitFullscreenEnabled);
-
 const getFullscreenElement = () =>
   document.fullscreenElement || document.webkitFullscreenElement || null;
 
@@ -157,7 +153,6 @@ export function App() {
   const [hintGone, setHintGone] = useState(false);
   const [holding, setHolding] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const [fullscreenAvailable, setFullscreenAvailable] = useState(false);
 
   // Draft inputs while the settings modal is open
   const [draftMins, setDraftMins] = useState(Math.floor(timerDuration / 60));
@@ -201,7 +196,6 @@ export function App() {
 
   // ---- Fullscreen ----
   useEffect(() => {
-    setFullscreenAvailable(isFullscreenSupported());
     const onChange = () => setIsFullscreen(!!getFullscreenElement());
     document.addEventListener('fullscreenchange', onChange);
     document.addEventListener('webkitfullscreenchange', onChange);
@@ -485,16 +479,14 @@ export function App() {
           {finished ? 'TIME' : 'PAUSED'}
         </div>
 
-        {fullscreenAvailable && (
-          <button
-            type="button"
-            className="fs-btn"
-            aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
-            onClick={toggleFullscreen}
-          >
-            {isFullscreen ? <ExitFullscreenIcon /> : <EnterFullscreenIcon />}
-          </button>
-        )}
+        <button
+          type="button"
+          className="fs-btn"
+          aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+          onClick={toggleFullscreen}
+        >
+          {isFullscreen ? <ExitFullscreenIcon /> : <EnterFullscreenIcon />}
+        </button>
       </div>
 
       <div

--- a/src/pages/scoreboard/_app/app.jsx
+++ b/src/pages/scoreboard/_app/app.jsx
@@ -577,6 +577,16 @@ export function App() {
             />
           </div>
 
+          <div className="row">
+            <label>Fullscreen</label>
+            <div
+              className={`toggle${isFullscreen ? ' on' : ''}`}
+              role="switch"
+              aria-checked={isFullscreen}
+              onClick={toggleFullscreen}
+            />
+          </div>
+
           <div className="actions">
             <button className="sb-btn sb-btn-primary" onClick={applyAndClose}>Done</button>
             <button className="sb-btn sb-btn-ghost" onClick={resetScores}>Reset scores</button>

--- a/src/pages/scoreboard/_app/app.jsx
+++ b/src/pages/scoreboard/_app/app.jsx
@@ -1,0 +1,511 @@
+import { createRoot } from 'react-dom/client';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useLocalStorage } from '../../../lib/useLocalStorage.js';
+import { ensureAudio, buzzer, tone } from './audio.js';
+import './app.css';
+
+const PREFIX = 'scoreboard_';
+
+const HOLD_MS = 600;
+const SWIPE_THRESHOLD = 40;
+const TAP_MAX_DURATION = 500;
+
+const PlayIcon = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14">
+    <path d="M8 5v14l11-7L8 5z" />
+  </svg>
+);
+const PauseIcon = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14">
+    <rect x="6" y="5" width="4" height="14" rx="1" />
+    <rect x="14" y="5" width="4" height="14" rx="1" />
+  </svg>
+);
+const SettingsIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="18" height="18">
+    <circle cx="12" cy="12" r="3" />
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+  </svg>
+);
+
+const vibe = (enabled, pattern) => {
+  if (enabled && typeof navigator !== 'undefined' && navigator.vibrate) {
+    try { navigator.vibrate(pattern); } catch { /* ignore */ }
+  }
+};
+
+const fmtTime = (s) => {
+  const m = Math.floor(s / 60);
+  const sec = s % 60;
+  return `${m.toString().padStart(2, '0')}:${sec.toString().padStart(2, '0')}`;
+};
+
+function Side({ side, label, score, increment, onScore, hintGone, onFirstInteraction }) {
+  const sideRef = useRef(null);
+  const startRef = useRef(null);
+  const [bumpClass, setBumpClass] = useState('');
+  const prevScoreRef = useRef(score);
+  const animTimerRef = useRef(null);
+
+  useEffect(() => {
+    if (score === prevScoreRef.current) return;
+    const up = score > prevScoreRef.current;
+    prevScoreRef.current = score;
+    setBumpClass('');
+    const raf = requestAnimationFrame(() => setBumpClass(up ? 'bump' : 'dip'));
+    clearTimeout(animTimerRef.current);
+    animTimerRef.current = setTimeout(() => setBumpClass(''), 240);
+    return () => {
+      cancelAnimationFrame(raf);
+      clearTimeout(animTimerRef.current);
+    };
+  }, [score]);
+
+  const handlePointerDown = (e) => {
+    if (e.target.closest('.timer-pill') || e.target.closest('.modal-backdrop')) return;
+    startRef.current = { x: e.clientX, y: e.clientY, t: Date.now() };
+    try { e.currentTarget.setPointerCapture(e.pointerId); } catch { /* ignore */ }
+  };
+
+  const handlePointerUp = (e) => {
+    const s = startRef.current;
+    if (!s) return;
+    startRef.current = null;
+
+    const dy = e.clientY - s.y;
+    const dx = e.clientX - s.x;
+    const dt = Date.now() - s.t;
+
+    // Ripple feedback — created via DOM since it's a fire-and-forget animation
+    const host = e.currentTarget;
+    const r = document.createElement('div');
+    r.className = 'ripple';
+    const rect = host.getBoundingClientRect();
+    r.style.left = (e.clientX - rect.left) + 'px';
+    r.style.top = (e.clientY - rect.top) + 'px';
+    host.appendChild(r);
+    setTimeout(() => r.remove(), 600);
+
+    onFirstInteraction();
+
+    if (Math.abs(dy) > SWIPE_THRESHOLD && Math.abs(dy) > Math.abs(dx)) {
+      onScore(dy < 0 ? increment : -increment);
+    } else if (dt < TAP_MAX_DURATION && Math.abs(dx) < 20 && Math.abs(dy) < 20) {
+      onScore(increment);
+    }
+  };
+
+  const handlePointerCancel = () => { startRef.current = null; };
+
+  return (
+    <div
+      ref={sideRef}
+      className={`side ${side}`}
+      data-side={side}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
+    >
+      <div className={`score ${bumpClass}`}>{score}</div>
+      <div className="label">{label}</div>
+      <div className={`hint ${hintGone ? 'gone' : ''}`}>Tap +1 · Swipe ↓ −1</div>
+    </div>
+  );
+}
+
+export function App() {
+  const [scoreLeft, setScoreLeft] = useLocalStorage('scoreLeft', 0, { prefix: PREFIX });
+  const [scoreRight, setScoreRight] = useLocalStorage('scoreRight', 0, { prefix: PREFIX });
+  const [timerDuration, setTimerDuration] = useLocalStorage('duration', 180, { prefix: PREFIX });
+  const [mode, setMode] = useLocalStorage('mode', 'down', { prefix: PREFIX });
+  const [increment, setIncrement] = useLocalStorage('increment', 1, { prefix: PREFIX });
+  const [sound, setSound] = useLocalStorage('sound', true, { prefix: PREFIX });
+  const [haptics, setHaptics] = useLocalStorage('haptics', true, { prefix: PREFIX });
+  const [wakeLockOn, setWakeLockOn] = useLocalStorage('wake', true, { prefix: PREFIX });
+
+  const startValue = mode === 'down' ? timerDuration : 0;
+  const [timerValue, setTimerValue] = useState(startValue);
+  const [timerRunning, setTimerRunning] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [hintGone, setHintGone] = useState(false);
+  const [holding, setHolding] = useState(false);
+
+  // Draft inputs while the settings modal is open
+  const [draftMins, setDraftMins] = useState(Math.floor(timerDuration / 60));
+  const [draftSecs, setDraftSecs] = useState(timerDuration % 60);
+
+  // Read-latest refs for values read inside the timer interval (avoids
+  // re-creating the interval whenever a setting toggles)
+  const settingsRef = useRef({ sound, haptics, wakeLockOn, mode, timerDuration });
+  settingsRef.current = { sound, haptics, wakeLockOn, mode, timerDuration };
+
+  const wakeLockRef = useRef(null);
+  const holdTimeoutRef = useRef(null);
+  const didHoldRef = useRef(false);
+
+  const finished = mode === 'down' ? timerValue <= 0 : timerValue >= timerDuration;
+  const idle = !timerRunning && timerValue === startValue;
+  const paused = !timerRunning && !idle && !finished;
+  const left = mode === 'down' ? timerValue : timerDuration - timerValue;
+  const warning = !finished && left > 0 && left <= 10;
+
+  // ---- Audio unlock on first user gesture anywhere ----
+  useEffect(() => {
+    const unlock = () => {
+      ensureAudio();
+      window.removeEventListener('pointerdown', unlock, true);
+      window.removeEventListener('keydown', unlock, true);
+    };
+    window.addEventListener('pointerdown', unlock, true);
+    window.addEventListener('keydown', unlock, true);
+    return () => {
+      window.removeEventListener('pointerdown', unlock, true);
+      window.removeEventListener('keydown', unlock, true);
+    };
+  }, []);
+
+  // ---- Wake lock ----
+  const requestWakeLock = useCallback(async () => {
+    if (!settingsRef.current.wakeLockOn || typeof navigator === 'undefined' || !('wakeLock' in navigator)) return;
+    try {
+      wakeLockRef.current = await navigator.wakeLock.request('screen');
+      wakeLockRef.current.addEventListener('release', () => { wakeLockRef.current = null; });
+    } catch { /* user gesture required or unsupported */ }
+  }, []);
+
+  const releaseWakeLock = useCallback(async () => {
+    if (wakeLockRef.current) {
+      try { await wakeLockRef.current.release(); } catch { /* ignore */ }
+      wakeLockRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible' && settingsRef.current.wakeLockOn) {
+        requestWakeLock();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => document.removeEventListener('visibilitychange', onVisibility);
+  }, [requestWakeLock]);
+
+  // ---- Timer tick ----
+  useEffect(() => {
+    if (!timerRunning) return;
+    const id = setInterval(() => {
+      setTimerValue(v => {
+        const s = settingsRef.current;
+        const next = s.mode === 'down' ? v - 1 : v + 1;
+        const isFinished = s.mode === 'down' ? next <= 0 : next >= s.timerDuration;
+        if (isFinished) {
+          const snap = s.mode === 'down' ? 0 : s.timerDuration;
+          // Defer the running-state flip so we don't update state mid-render
+          setTimeout(() => setTimerRunning(false), 0);
+          if (s.mode === 'down') {
+            buzzer(s.sound);
+            vibe(s.haptics, [240, 100, 240, 100, 480]);
+          } else {
+            vibe(s.haptics, [180, 80, 180, 80, 320]);
+          }
+          return snap;
+        }
+        const leftSec = s.mode === 'down' ? next : s.timerDuration - next;
+        if (leftSec > 0 && leftSec <= 5) vibe(s.haptics, 35);
+        return next;
+      });
+    }, 1000);
+    return () => clearInterval(id);
+  }, [timerRunning]);
+
+  // Acquire wake lock when the timer starts running
+  useEffect(() => {
+    if (timerRunning) requestWakeLock();
+  }, [timerRunning, requestWakeLock]);
+
+  // ---- Score updates ----
+  const updateScore = (side, delta) => {
+    const cur = side === 'left' ? scoreLeft : scoreRight;
+    const next = Math.max(0, cur + delta);
+    if (next === cur) {
+      vibe(haptics, 5);
+      return;
+    }
+    if (side === 'left') setScoreLeft(next); else setScoreRight(next);
+    vibe(haptics, delta > 0 ? 18 : 10);
+  };
+
+  // ---- Timer interactions ----
+  const startTimer = () => {
+    if (timerRunning || finished) return;
+    ensureAudio();
+    setTimerRunning(true);
+  };
+  const stopTimer = () => setTimerRunning(false);
+  const resetTimer = () => {
+    setTimerRunning(false);
+    setTimerValue(mode === 'down' ? timerDuration : 0);
+    vibe(haptics, [30, 30, 30]);
+  };
+
+  const onTimerPointerDown = (e) => {
+    if (e.target.closest('.settings-btn')) return;
+    didHoldRef.current = false;
+    setHolding(true);
+    holdTimeoutRef.current = setTimeout(() => {
+      didHoldRef.current = true;
+      resetTimer();
+      setHolding(false);
+    }, HOLD_MS);
+  };
+  const endHold = () => {
+    if (holdTimeoutRef.current) {
+      clearTimeout(holdTimeoutRef.current);
+      holdTimeoutRef.current = null;
+    }
+    setHolding(false);
+  };
+  const onTimerPointerUp = (e) => {
+    if (e.target.closest('.settings-btn')) { endHold(); return; }
+    endHold();
+    if (didHoldRef.current) return;
+    if (timerRunning) stopTimer(); else startTimer();
+  };
+
+  // ---- Settings modal ----
+  const openSettings = (e) => {
+    e?.stopPropagation();
+    setDraftMins(Math.floor(timerDuration / 60));
+    setDraftSecs(timerDuration % 60);
+    setModalOpen(true);
+  };
+  const applyAndClose = () => {
+    const m = Math.max(0, Math.min(99, parseInt(draftMins) || 0));
+    const s = Math.max(0, Math.min(59, parseInt(draftSecs) || 0));
+    const total = Math.max(1, m * 60 + s);
+    const durationChanged = total !== timerDuration;
+    setTimerDuration(total);
+    if (!timerRunning && (durationChanged || idle || finished)) {
+      setTimerValue(mode === 'down' ? total : 0);
+    }
+    setModalOpen(false);
+  };
+
+  const changeMode = (newMode) => {
+    if (newMode === mode) return;
+    setMode(newMode);
+    setTimerRunning(false);
+    setTimerValue(newMode === 'down' ? timerDuration : 0);
+  };
+
+  const toggleSound = () => {
+    const next = !sound;
+    setSound(next);
+    if (next) {
+      ensureAudio();
+      tone(880, 0, 0.12, 'square', 0.22); // test pip so user knows it works
+    }
+  };
+  const toggleHaptics = () => {
+    const next = !haptics;
+    setHaptics(next);
+    if (next) vibe(true, 20);
+  };
+  const toggleWake = () => {
+    const next = !wakeLockOn;
+    setWakeLockOn(next);
+    if (next) requestWakeLock(); else releaseWakeLock();
+  };
+
+  const resetScores = () => {
+    setScoreLeft(0);
+    setScoreRight(0);
+    vibe(haptics, 40);
+  };
+  const resetEverything = () => {
+    setScoreLeft(0);
+    setScoreRight(0);
+    setTimerRunning(false);
+    setTimerValue(mode === 'down' ? timerDuration : 0);
+    vibe(haptics, [40, 60, 40]);
+  };
+
+  // Prevent context menu / iOS gesture zoom
+  useEffect(() => {
+    const onContext = (e) => e.preventDefault();
+    const onGesture = (e) => e.preventDefault();
+    document.addEventListener('contextmenu', onContext);
+    document.addEventListener('gesturestart', onGesture);
+    return () => {
+      document.removeEventListener('contextmenu', onContext);
+      document.removeEventListener('gesturestart', onGesture);
+    };
+  }, []);
+
+  return (
+    <>
+      <div className="scoreboard">
+        <Side
+          side="left"
+          label="Home"
+          score={scoreLeft}
+          increment={increment}
+          onScore={(d) => updateScore('left', d)}
+          hintGone={hintGone}
+          onFirstInteraction={() => !hintGone && setHintGone(true)}
+        />
+        <Side
+          side="right"
+          label="Away"
+          score={scoreRight}
+          increment={increment}
+          onScore={(d) => updateScore('right', d)}
+          hintGone={hintGone}
+          onFirstInteraction={() => !hintGone && setHintGone(true)}
+        />
+
+        <div
+          className={[
+            'timer-pill',
+            paused ? 'paused' : '',
+            warning ? 'warning' : '',
+            holding ? 'holding' : '',
+          ].filter(Boolean).join(' ')}
+          onPointerDown={onTimerPointerDown}
+          onPointerUp={onTimerPointerUp}
+          onPointerCancel={endHold}
+          onPointerLeave={endHold}
+        >
+          <div className="hold-ring" />
+          <div className="timer-icon" aria-label="play/pause indicator">
+            {timerRunning ? <PauseIcon /> : <PlayIcon />}
+          </div>
+          <div className="timer-text">{fmtTime(timerValue)}</div>
+          <div
+            className="timer-icon btn settings-btn"
+            aria-label="Settings"
+            role="button"
+            onClick={openSettings}
+          >
+            <SettingsIcon />
+          </div>
+        </div>
+
+        <div
+          className={[
+            'timer-badge',
+            finished ? 'show done' : paused ? 'show' : '',
+          ].filter(Boolean).join(' ')}
+        >
+          {finished ? 'TIME' : 'PAUSED'}
+        </div>
+
+        <div className="rotate-warning">
+          <div className="phone-icon" />
+          <h1>Rotate to landscape</h1>
+          <p>This scoreboard is designed for landscape orientation.</p>
+        </div>
+      </div>
+
+      <div
+        className={`modal-backdrop${modalOpen ? ' show' : ''}`}
+        onClick={(e) => { if (e.target === e.currentTarget) applyAndClose(); }}
+      >
+        <div className="modal" role="dialog" aria-label="Scoreboard settings">
+          <h2>Scoreboard</h2>
+          <div className="sub">Settings</div>
+
+          <div className="row">
+            <label>Match length</label>
+            <div className="time-input">
+              <input
+                type="number"
+                min="0"
+                max="99"
+                value={draftMins}
+                inputMode="numeric"
+                onChange={(e) => setDraftMins(e.target.value)}
+              />
+              <span>:</span>
+              <input
+                type="number"
+                min="0"
+                max="59"
+                value={draftSecs}
+                inputMode="numeric"
+                onChange={(e) => setDraftSecs(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="row">
+            <label>Timer mode</label>
+            <div className="mode-pick">
+              <button
+                className={mode === 'down' ? 'on' : ''}
+                onClick={() => changeMode('down')}
+              >Count down</button>
+              <button
+                className={mode === 'up' ? 'on' : ''}
+                onClick={() => changeMode('up')}
+              >Count up</button>
+            </div>
+          </div>
+
+          <div className="row">
+            <label>Point increment</label>
+            <div className="inc-pick">
+              {[1, 2, 3, 5].map(n => (
+                <button
+                  key={n}
+                  className={increment === n ? 'on' : ''}
+                  onClick={() => setIncrement(n)}
+                >{n}</button>
+              ))}
+            </div>
+          </div>
+
+          <div className="row">
+            <label>Buzzer at full time</label>
+            <div
+              className={`toggle${sound ? ' on' : ''}`}
+              role="switch"
+              aria-checked={sound}
+              onClick={toggleSound}
+            />
+          </div>
+
+          <div className="row">
+            <label>Haptic feedback</label>
+            <div
+              className={`toggle${haptics ? ' on' : ''}`}
+              role="switch"
+              aria-checked={haptics}
+              onClick={toggleHaptics}
+            />
+          </div>
+
+          <div className="row">
+            <label>Keep screen awake</label>
+            <div
+              className={`toggle${wakeLockOn ? ' on' : ''}`}
+              role="switch"
+              aria-checked={wakeLockOn}
+              onClick={toggleWake}
+            />
+          </div>
+
+          <div className="actions">
+            <button className="sb-btn sb-btn-primary" onClick={applyAndClose}>Done</button>
+            <button className="sb-btn sb-btn-ghost" onClick={resetScores}>Reset scores</button>
+            <button className="sb-btn sb-btn-danger" onClick={resetEverything}>Reset everything</button>
+            <a className="sb-btn sb-btn-ghost" href="../">← Home</a>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+const mount = document.getElementById('app');
+if (mount) createRoot(mount).render(<App historyUrl={mount.dataset.historyUrl} />);

--- a/src/pages/scoreboard/_app/app.test.jsx
+++ b/src/pages/scoreboard/_app/app.test.jsx
@@ -1,0 +1,29 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { App } from './app.jsx';
+
+afterEach(cleanup);
+
+describe('Scoreboard', () => {
+  beforeEach(() => { localStorage.clear(); });
+
+  test('renders both sides with starting scores', () => {
+    const { container } = render(<App />);
+    const scores = container.querySelectorAll('.score');
+    expect(scores.length).toBe(2);
+    expect(scores[0].textContent).toBe('0');
+    expect(scores[1].textContent).toBe('0');
+  });
+
+  test('renders the timer at the default 3:00', () => {
+    const { container } = render(<App />);
+    expect(container.querySelector('.timer-text').textContent).toBe('03:00');
+  });
+
+  test('has a home link inside the settings modal', () => {
+    render(<App />);
+    fireEvent.click(screen.getByLabelText('Settings'));
+    const home = screen.getByText('← Home').closest('a');
+    expect(home.getAttribute('href')).toBe('../');
+  });
+});

--- a/src/pages/scoreboard/_app/audio.js
+++ b/src/pages/scoreboard/_app/audio.js
@@ -1,0 +1,50 @@
+let audioCtx = null;
+
+// iOS requires AudioContext creation/resume inside a user gesture, so we
+// lazily initialise on the first interaction anywhere on the page.
+export function ensureAudio() {
+  if (audioCtx) {
+    if (audioCtx.state === 'suspended') audioCtx.resume().catch(() => {});
+    return;
+  }
+  try {
+    const Ctx = window.AudioContext || window.webkitAudioContext;
+    if (!Ctx) return;
+    audioCtx = new Ctx();
+    // Play a silent buffer to fully unlock audio on iOS
+    const buffer = audioCtx.createBuffer(1, 1, 22050);
+    const src = audioCtx.createBufferSource();
+    src.buffer = buffer;
+    src.connect(audioCtx.destination);
+    src.start(0);
+  } catch { /* unsupported */ }
+}
+
+export function tone(freq, startOffset, duration, type = 'square', volume = 0.32) {
+  if (!audioCtx) return;
+  const osc = audioCtx.createOscillator();
+  const gain = audioCtx.createGain();
+  osc.type = type;
+  osc.frequency.value = freq;
+  osc.connect(gain);
+  gain.connect(audioCtx.destination);
+  const t = audioCtx.currentTime + startOffset;
+  gain.gain.setValueAtTime(0, t);
+  gain.gain.linearRampToValueAtTime(volume, t + 0.012);
+  gain.gain.setValueAtTime(volume, t + Math.max(0, duration - 0.05));
+  gain.gain.exponentialRampToValueAtTime(0.0001, t + duration);
+  osc.start(t);
+  osc.stop(t + duration + 0.02);
+}
+
+// Three short pips followed by a long horn — classic sports buzzer feel
+export function buzzer(soundEnabled) {
+  if (!soundEnabled) return;
+  ensureAudio();
+  if (!audioCtx) return;
+  tone(880, 0.00, 0.16, 'square', 0.28);
+  tone(880, 0.24, 0.16, 'square', 0.28);
+  tone(880, 0.48, 0.16, 'square', 0.28);
+  tone(523, 0.78, 1.10, 'sawtooth', 0.34);
+  tone(262, 0.78, 1.10, 'square',   0.18);
+}

--- a/src/pages/scoreboard/index.astro
+++ b/src/pages/scoreboard/index.astro
@@ -1,0 +1,13 @@
+---
+import AppLayout from '../../layouts/AppLayout.astro';
+---
+<AppLayout title="Scoreboard">
+  <Fragment slot="head">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <meta name="theme-color" content="#4F65E5" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Big+Shoulders+Display:wght@700;800;900&family=Bricolage+Grotesque:wght@500;600;700&display=swap" rel="stylesheet" />
+  </Fragment>
+  <script>import './_app/app.jsx';</script>
+</AppLayout>


### PR DESCRIPTION
Two-tap scoring (tap = +1, swipe down = −1) with a configurable match
timer (count up or down), buzzer at full-time, haptics, and a settings
modal for everything. Ported from the user-provided vanilla HTML/JS to
the React + AppLayout template.