### PR TITLE
Close coffee merge café at midnight instead of 10pm

### DIFF
--- a/src/pages/coffee-merge/_app/game.js
+++ b/src/pages/coffee-merge/_app/game.js
@@ -83,10 +83,12 @@ function createDrink(x, y, tier, vx = 0, vy = 0) {
   return body;
 }
 
-// Café hours: closed 10pm–6am local time. The shutter overlay covers the
+// Café hours: closed midnight–6am local time. The shutter overlay covers the
 // viewport during closed hours; `paused` gates the engine and input.
+// CLOSE_HOUR is 24 (rather than 0) so `h >= CLOSE_HOUR` never matches and the
+// closed window is driven purely by `h < OPEN_HOUR`.
 const OPEN_HOUR = 6;
-const CLOSE_HOUR = 22;
+const CLOSE_HOUR = 24;
 let paused = false;
 let prevClosed = null;
 

--- a/src/pages/coffee-merge/index.astro
+++ b/src/pages/coffee-merge/index.astro
@@ -48,7 +48,7 @@
     // slide-down animation, no flash of the leaderboard, no input window.
     (function () {
       var h = new Date().getHours();
-      if (h >= 22 || h < 6) {
+      if (h < 6) {
         document.getElementById('shutter').classList.add('is-closed', 'no-anim');
       }
     })();


### PR DESCRIPTION
Café now stays open until midnight (closed midnight–6am). CLOSE_HOUR is
set to 24 so the closed window is driven by OPEN_HOUR only, and the
index.astro pre-paint check drops the redundant evening branch.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AWKhzYXWytzsZj6X7BwF8c